### PR TITLE
Fixed refreshing day event dots

### DIFF
--- a/app/src/main/kotlin/org/fossify/calendar/fragments/MonthDayFragment.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/fragments/MonthDayFragment.kt
@@ -156,6 +156,7 @@ class MonthDayFragment : Fragment(), MonthlyCalendar, RefreshRecyclerViewListene
                 } else {
                     (currAdapter as EventListAdapter).updateListItems(listItems)
                 }
+                updateCalendar()
             }
         }
     }


### PR DESCRIPTION
There is a bug that event markers on Monthly and daily view are not removed after removing an event. Here's the original bug report from SMT:

> If a given days events are deleted by long pressing an event and using Delete at the top menu and the given day no longer contains events, the dots under date should be removed too.

This PR fixes that issue.

**Before:**

https://github.com/FossifyOrg/Calendar/assets/85929121/288dcabe-f89c-4380-b055-8091fee0f5ad

**After:**

https://github.com/FossifyOrg/Calendar/assets/85929121/3c27cd6d-dce1-475f-8dd5-d95db83f827b

