### PR TITLE
Add content description on chevron next/previous day/month

### DIFF
--- a/app/src/main/kotlin/org/fossify/calendar/fragments/DayFragment.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/fragments/DayFragment.kt
@@ -7,6 +7,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import org.fossify.calendar.R
 import org.fossify.calendar.activities.MainActivity
 import org.fossify.calendar.activities.SimpleActivity
 import org.fossify.calendar.adapters.DayEventsAdapter
@@ -56,6 +57,7 @@ class DayFragment : Fragment() {
             val pointerLeft = requireContext().getDrawable(org.fossify.commons.R.drawable.ic_chevron_left_vector)
             pointerLeft?.isAutoMirrored = true
             setImageDrawable(pointerLeft)
+            contentDescription = getString(R.string.accessibility_previous_day)
         }
 
         topNavigationBinding.topRightArrow.apply {
@@ -68,6 +70,7 @@ class DayFragment : Fragment() {
             val pointerRight = requireContext().getDrawable(org.fossify.commons.R.drawable.ic_chevron_right_vector)
             pointerRight?.isAutoMirrored = true
             setImageDrawable(pointerRight)
+            contentDescription = getString(R.string.accessibility_next_day)
         }
 
         val day = Formatter.getDayTitle(requireContext(), mDayCode)

--- a/app/src/main/kotlin/org/fossify/calendar/fragments/MonthFragment.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/fragments/MonthFragment.kt
@@ -7,6 +7,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import org.fossify.calendar.R
 import org.fossify.calendar.activities.MainActivity
 import org.fossify.calendar.databinding.FragmentMonthBinding
 import org.fossify.calendar.databinding.TopNavigationBinding
@@ -120,6 +121,7 @@ class MonthFragment : Fragment(), MonthlyCalendar {
             val pointerLeft = requireContext().getDrawable(org.fossify.commons.R.drawable.ic_chevron_left_vector)
             pointerLeft?.isAutoMirrored = true
             setImageDrawable(pointerLeft)
+            contentDescription = getString(R.string.accessibility_previous_month)
         }
 
         topNavigationBinding.topRightArrow.apply {
@@ -132,6 +134,7 @@ class MonthFragment : Fragment(), MonthlyCalendar {
             val pointerRight = requireContext().getDrawable(org.fossify.commons.R.drawable.ic_chevron_right_vector)
             pointerRight?.isAutoMirrored = true
             setImageDrawable(pointerRight)
+            contentDescription = getString(R.string.accessibility_next_month)
         }
 
         topNavigationBinding.topValue.apply {

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -274,6 +274,11 @@
         <item quantity="many">خلال الاشهر التالية %d</item>
         <item quantity="other">خلال الشهر التالي %d</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">كيف يمكنني حذف العطلات المنقولة عن طريق زر \"أضف عطلات\"؟</string>
     <string name="faq_1_text">العطلات المضافة بهذه الطريقة تدخل تحت نوع جديد يسمى \"العطلات\". يمكنك الذهاب الى الإعدادات -&gt; إدارة أنواع الأحداث، ثم اضغط مطولا على نوع الحدث واحذفه عن طريق اختيار سلة المهملات.</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -262,6 +262,11 @@
         <item quantity="one">Within the next %d month</item>
         <item quantity="other">Within the next %d months</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">How can I remove the holidays imported via the \"Add holidays\" button\?</string>
     <string name="faq_1_text">Holidays created that way are inserted in a new event type called \"Holidays\". You can go in Settings -&gt; Manage Event Types, long press the given event type and delete it by selecting the trashbin.</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -268,6 +268,11 @@
         <item quantity="many">На працягу наступных %d месяцаў</item>
         <item quantity="other">На працягу наступных %d месяцаў</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">Як я магу выдаліць святы, імпартаваныя праз кнопку \"Дадаць святы\"\?</string>
     <string name="faq_1_text">Святы, створаныя такім чынам, устаўляюцца ў новы тып падзеі пад назвай \"Святы\". Вы можаце перайсці ў Налады -&gt; Кіраванне тыпамі падзей, доўга націскаць на дадзены тып падзеі і выдаліць яго, выбраўшы сметніцу.</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -262,6 +262,11 @@
         <item quantity="one">В следващата %d седмица</item>
         <item quantity="other">В следващите %d седмици</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">Как мога да премахна празниците, импортирани чрез бутона \"Добавяне на празници\"\?</string>
     <string name="faq_1_text">Създадените по този начин празници се вмъкват в нов тип събитие, наречен \"Празници\". Можете да отидете в Настройки -&gt; Управление на типове събития, да натиснете продължително дадения тип събитие и да го изтриете, като изберете кошчето за боклук.</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -262,6 +262,11 @@
         <item quantity="one">Within the next %d month</item>
         <item quantity="other">Within the next %d months</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">আমি কীভাবে \"ছুটি যুক্ত করুন\?\" বাটনের মাধ্যমে ইমপোর্ট করা ছুটিগুলি সরিয়ে ফেলতে পারি\?</string>
     <string name="faq_1_text">\"ছুটির দিন\" নামে নতুন ইভেন্ট টাইপ ইনসার্ট করার মাধ্যমে ছুটির দিন তৈরি হয়।</string>

--- a/app/src/main/res/values-br/strings.xml
+++ b/app/src/main/res/values-br/strings.xml
@@ -262,6 +262,11 @@
         <item quantity="one">Within the next %d month</item>
         <item quantity="other">Within the next %d months</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">How can I remove the holidays imported via the \"Add holidays\" button\?</string>
     <string name="faq_1_text">Holidays created that way are inserted in a new event type called \"Holidays\". You can go in Settings -&gt; Manage Event Types, long press the given event type and delete it by selecting the trashbin.</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -262,6 +262,11 @@
         <item quantity="one">En el %d mes següent</item>
         <item quantity="other">En els %d mesos següents</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">Com puc eliminar els dies festius importats mitjançant el botó «Afegeix festius»\?</string>
     <string name="faq_1_text">Els dies festius creats d\'aquesta manera s\'insereixen en un tipus d\'esdeveniment nou anomenat «Festius». Podeu anar a Configuració -&gt; Gestiona els tipus d\'esdeveniments, prémer prolongadament el tipus d\'esdeveniment indicat i suprimir-lo seleccionant la paperera.</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -265,6 +265,11 @@
         <item quantity="few">v průběhu %d měsíců</item>
         <item quantity="other">v průběhu %d měsíců</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">Jak mohu odstranit svátky importované pomocí tlačítka „Přidat svátky“\?</string>
     <string name="faq_1_text">Svátky vytvořené touto cestou jsou vloženy pod novým typem události „Svátky“. Odstranit je můžete přes: Nastavení -&gt; Správa typů událostí -&gt; dlouze podržte daný typ události a stiskněte tlačítko s ikonou koše pro odstranění.</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -262,6 +262,11 @@
         <item quantity="one">I løbet af %d måned</item>
         <item quantity="other">I løbet af de næste %d måneder</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">Hvordan kan jeg fjerne helligdage der er importeret med funktionen \"Tilføj helligdage\"\?</string>
     <string name="faq_1_text">Helligdage oprettet på den måde er indsat under begivenhedstypen \"Helligdage\". Gå til Indstillinger -&gt; Håndter begivenhedstyper. Efter et par sekunders pres på en type kan du slette den ved at klikke på papirkurven.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -262,6 +262,11 @@
         <item quantity="one">Innerhalb des nächsten Monats</item>
         <item quantity="other">Innerhalb der nächsten %d Monate</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">Wie kann ich Feiertage löschen, die über „Feiertage hinzufügen“ importiert wurden\?</string>
     <string name="faq_1_text">Die über diesen Weg erstellten Feiertage sind als Termintyp „Feiertage“ deklariert. Du kannst in den Einstellungen -&gt; Termintypen verwalten auf den Termintyp gedrückt halten und über das Papierkorbsymbol löschen.</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -262,6 +262,11 @@
         <item quantity="one">Εντός στον επόμενο %d μήνα</item>
         <item quantity="other">Εντός στις επόμενες %d μήνες</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">Πώς μπορώ να αφαιρέσω τις αργίες που εισήχθησαν μέσω του κουμπιού \"Προσθήκη αργιών\" ;</string>
     <string name="faq_1_text">Οι αργίες που δημιουργήθηκαν με τον τρόπο αυτό εισάγονται σε ένα νέο τύπο εκδήλωσης που ονομάζεται \"Αργίες \". Μπορείτε να μεταβείτε στις Ρυθμίσεις -&gt; Διαχείριση τύπων εκδηλώσεων, πατώντας παρατεταμένα τον συγκεκριμένο τύπο εκδήλωσης και διαγράψτε το επιλέγοντας τον Κάδο.</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -262,6 +262,11 @@
         <item quantity="one">Within the next %d month</item>
         <item quantity="other">Within the next %d months</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">How can I remove the holidays imported via the \"Add holidays\" button\?</string>
     <string name="faq_1_text">Holidays created that way are inserted in a new event type called \"Holidays\". You can go in Settings -&gt; Manage Event Types, long press the given event type and delete it by selecting the trashbin.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -265,6 +265,11 @@
         <item quantity="many">En los próximos meses %d</item>
         <item quantity="other">En los próximos meses %d</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">¿Cómo puedo eliminar los festivos importados a través del botón \"Añadir festivos\"\?</string>
     <string name="faq_1_text">A los eventos creados de esta forma se les asigna el tipo de evento \"Festivos\". En Ajustes -&gt; Gestionar tipos de evento, mantén pulsado el tipo de evento para seleccionarlo y elimínalo pulsando en la papelera.</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -262,6 +262,11 @@
         <item quantity="one">Järgmise %d kuu jooksul</item>
         <item quantity="other">Järgmise %d kuu jooksul</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">Kuidas ma saan eemaldada nupu „Lisa pühad“ kaudu imporditud pühad\?</string>
     <string name="faq_1_text">Sel viisil loodud pühad lisatakse uude sündmuse tüüpi nimega „Pühad“. Ava menüüs Seaded -&gt; Halda sündmuste tüüp, vajuta pikalt antud sündmuse tüübile ja valides prügikasti kustuta see kirje.</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -262,6 +262,11 @@
         <item quantity="one">Hurrengo %d hilabetean</item>
         <item quantity="other">Hurrengo %d hilabetetan</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">Nola kendu ditzaket \"Gehitu jaiegunak\" botoiarekin inportatutako jaiegunak\?</string>
     <string name="faq_1_text">Modu horretan sortutako jaiegunak \"Jaiegunak\" deituriko gertaera mota berrian sartzen dira. Joan Ezarpenak -&gt; Kudeatu gertaera motak atalera, sakatu luze gertaera mota hori eta ezabatu zakarrontzia hautatuz.</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -262,6 +262,11 @@
         <item quantity="one">Tulevan kuukauden aikana</item>
         <item quantity="other">Tulevien %d kuukauden aikana</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">Kuinka voin poistaa \"Lisää juhlapäivät\"-painikkeella tuotuja juhlapäiviä\?</string>
     <string name="faq_1_text">Näin luodut juhlapäivät lisätään uuteen tapahtumatyyppiin nimeltä \"Juhlapäivät\". Siirry kohtaan Asetukset -&gt; Hallitse tapahtumatyyppejä, paina pitkään annettua tapahtuman tyyppiä ja poista se valitsemalla roskakorin kuvaa.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -265,6 +265,11 @@
         <item quantity="many">Au cours des %d prochains mois</item>
         <item quantity="other">Au cours des %d prochains mois</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">Comment puis-je supprimer les jours fériés importés avec le bouton « Ajouter des jours fériés » \?</string>
     <string name="faq_1_text">Les jours fériés ainsi créés sont insérés dans un nouveau type d\'évènement appelé « Jours fériés ». Vous pouvez aller dans « Paramètres » -&gt; « Gérer les types d\'événements », et appuyer longuement sur le type d\'évènement concerné et le supprimer en sélectionnant la corbeille.</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -262,6 +262,11 @@
         <item quantity="one">No próximo %d mes</item>
         <item quantity="other">Nos próximos %d meses</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">Como podo eliminar os días festivos engadidos mediante o botón \"Engadir días festivos\"\?</string>
     <string name="faq_1_text">Os días festivos creados dese xeito insírense nun tipo de evento chamado \"Festivo\". Podes ir a Axustes -&gt; Xestionar tipos de eventos, manter preso o tipo de evento desexado e eliminalo escollendo a Papeleira do lixo.</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -262,6 +262,11 @@
         <item quantity="one">Within the next %d month</item>
         <item quantity="other">Within the next %d months</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">How can I remove the holidays imported via the \"Add holidays\" button\?</string>
     <string name="faq_1_text">Holidays created that way are inserted in a new event type called \"Holidays\". You can go in Settings -&gt; Manage Event Types, long press the given event type and delete it by selecting the trashbin.</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -265,6 +265,11 @@
         <item quantity="few">U iduća %d mjeseca</item>
         <item quantity="other">U idućih %d mjeseci</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">Kako mogu ukloniti praznike uvezene putem gumba „Dodaj praznik”\?</string>
     <string name="faq_1_text">Praznik koji je stvoren na taj način umetnut je u novu vrstu događaja pod nazivom „Praznici”. Idi u Postavke -&gt; Upravljanje vrstama događaja, dugo pritisni zadanu vrstu događaja i izbriši ga odabirom koša za smeće.</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -262,6 +262,11 @@
         <item quantity="one">A következő %d hónapban</item>
         <item quantity="other">A következő %d hónapban</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">Hogyan távolíthatom el az „Ünnepnapok hozzáadása” gombbal importált ünnepnapokat\?</string>
     <string name="faq_1_text">Az így létrehozott ünnepnapok az új „Ünnepnapok” eseménytípusba kerül beszúrásra. Menjen a Beállítások -&gt; Eseménytípusok kezelése lehetőséghez, nyomja meg hosszan az eseménytípust, majd törölje a kuka ikon választásával.</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -262,6 +262,11 @@
         <item quantity="one">Within the next %d month</item>
         <item quantity="other">Within the next %d months</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">Bagaimana cara menghapus hari libur yang diimpor via tombol \"Tambah hari libur\"\?</string>
     <string name="faq_1_text">Hari libur yang dibuat dengan cara tersebut disimpan di dalam kategori acara baru dengan nama \"Hari Libur\". Anda bisa mengunjungi Pengaturan -&gt; Kelola Kategori Acara, tekan lama kategori acara tersebut dan hapus dengan cara menekan tombol keranjang sampah.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -265,6 +265,13 @@
         <item quantity="many">Durante i prossimi %d mesi</item>
         <item quantity="other">Durante i prossimi %d mesi</item>
     </plurals>
+
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Vai al mese precedente</string>
+    <string name="accessibility_next_month">Vai al mese successivo</string>
+    <string name="accessibility_previous_day">Vai al giorno precedente</string>
+    <string name="accessibility_next_day">Vai al giorno successivo</string>
+
     <!-- FAQ -->
     <string name="faq_1_title">Come posso rimuovere le festività importate tramite il pulsante «Aggiungi festività»\?</string>
     <string name="faq_1_text">Le festività create in questo modo sono inseriti in eventi di tipo «Festività». Andare in Impostazioni → Gestisci tipi di eventi, tenere premuto sul tipo desiderato ed eliminarlo selezionando il cestino.</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -262,6 +262,11 @@
         <item quantity="one">Within the next %d month</item>
         <item quantity="other">Within the next %d months</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">How can I remove the holidays imported via the \"Add holidays\" button\?</string>
     <string name="faq_1_text">Holidays created that way are inserted in a new event type called \"Holidays\". You can go in Settings -&gt; Manage Event Types, long press the given event type and delete it by selecting the trashbin.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -260,6 +260,11 @@
     <plurals name="within_the_next_months">
         <item quantity="other">今後 %d ヶ月分</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">「祝日を追加」ボタンでインポートした祝日を削除するにはどうすればいいですか？</string>
     <string name="faq_1_text">この方法で作成された祝日は、「祝日」という新しい予定の種類に追加されます。この「祝日」という予定の種類を削除するには、設定の「予定の種類を管理」で対象の予定の種類を長押してごみ箱を選択する必要があります。</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -262,6 +262,11 @@
         <item quantity="one">Within the next %d month</item>
         <item quantity="other">Within the next %d months</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">공휴일 추가 버튼을 통해 불러온 공휴일을 제거하기 위해선 어떻게 해야하나요\?</string>
     <string name="faq_1_text">공휴일 추가 버튼을 통해 만든 공휴일은 \"공휴일\"이라는 새 일정 유형에 삽입됩니다. 설정 -&gt; 일정 유형 관리로 이동하여 해당 일정 유형을 길게누르고 휴지통을 선택하여 삭제할 수 있습니다.</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -265,6 +265,11 @@
         <item quantity="few">%d mėnesių bėgyje</item>
         <item quantity="other">%d mėnesių bėgyje</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">Kaip galiu pašalinti šventines dienas, importuotas naudojant mygtuką „Pridėti šventines dienas“\?</string>
     <string name="faq_1_text">Tuo būdu sukurtos šventinės dienos yra įterpiamos į naują įvykių tipą, pavadinimu „Šventinės dienos“. Pereikite į „Nustatymai“ -&gt; „Tvarkyti įvykių tipus“, paspauskite ir ilgiau palaikykite ant nurodyto įvykio tipo ir ištrinkite jį baksteldami ant šiukšlinės.</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -265,6 +265,11 @@
         <item quantity="one">Within the next %d month</item>
         <item quantity="other">Within the next %d months</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">Kā izdzēst svētku dienas, kas importētas, izmantojot pogu Pievienot svētkus\?</string>
     <string name="faq_1_text">Šādi izveidotas svētku dienas tiek piešķirts jauns notikumu tips - Svētku dienas. Dodieties uz sadaļu \"Iestatījumi \" -&gt; \"Notikumu tipu pārvaldīšana/, tad ilgs nospiediens uz āttiecīgā notikuma tipa un tā izdzēšana ar nospiedienu uz /misenes/.</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -263,6 +263,11 @@
         <item quantity="one">Во текот на следниот %d месец</item>
         <item quantity="other">Во следните %d месеци</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">Како можам да ги отстранам празниците увезени преку копчето \"Додади празници\"\?</string>
     <string name="faq_1_text">Празниците создадени така се внесуваат во нов тип на настани наречен \"Празници\". Можете да одите на Settings -&gt; Manage Event Types, долго да го притиснете дадениот тип на настан и да го избришете со избирање на ѓубрето.</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -261,6 +261,11 @@
         <item quantity="one">Within the next %d month</item>
         <item quantity="other">Within the next %d months</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">How can I remove the holidays imported via the \"Add holidays\" button?</string>
     <string name="faq_1_text">Holidays created that way are inserted in a new event type called \"Holidays\". You can go in Settings -&gt; Manage Event Types,

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -262,6 +262,11 @@
         <item quantity="one">Innen neste %d måned</item>
         <item quantity="other">Innen de neste %d månedene</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">Hvordan kan jeg fjerne off. fridager importert via meny - \"Legg til off. fridager\"\?</string>
     <string name="faq_1_text">Off. fridager opprettet på denne måten settes inn i en ny hendelsestype kalt \"Off. fridager\". Gå til Innstillinger -&gt; Behandle hendelsestyper, lang-trykk hendelsestypen og slett den ved å velge søppelbøtten.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -262,6 +262,11 @@
         <item quantity="one">Binnen de komende %d maand</item>
         <item quantity="other">Binnen de komende %d maanden</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">Hoe kan ik de feestdagen die zijn geïmporteerd via \"Feestdagen toevoegen\" weer verwijderen\?</string>
     <string name="faq_1_text">Deze feestdagen hebben het afspraaktype \"Feestdagen\". Om de feestdagen te verwijderen, ga naar Instellingen -&gt; Afspraaktypes beheren, druk lang op \"Feestdagen\" en druk vervolgens op de prullenbak.</string>

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -262,6 +262,11 @@
         <item quantity="one">Innen neste %d veke</item>
         <item quantity="other">Innen dei neste %d vekene</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">Korleis kan eg ta bort dei off. fridagane førte inn med «Legg til off. fridagar» i menyen\?</string>
     <string name="faq_1_text">Off. fridagar laga på det viset vert satt inn i eit nytt hendingsslag kalt «Off. fridagar». Gå til «Innstillingar → Handsam hendingsslag», hald inne på hendingsslaget for å velja det, og trykk på søppeldunken for å slette det.</string>

--- a/app/src/main/res/values-or/strings.xml
+++ b/app/src/main/res/values-or/strings.xml
@@ -283,6 +283,12 @@
         <item quantity="other">Within the next %d months</item>
     </plurals>
 
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
+
     <!-- FAQ -->
     <string name="faq_1_title">How can I remove the holidays imported via the \"Add holidays\" button?</string>
     <string name="faq_1_text">Holidays created that way are inserted in a new event type called \"Holidays\". You can go in Settings -> Manage Event Types,

--- a/app/src/main/res/values-pa-rPK/strings.xml
+++ b/app/src/main/res/values-pa-rPK/strings.xml
@@ -240,6 +240,13 @@
         <item quantity="one">Within the next %d week</item>
         <item quantity="other">Within the next %d weeks</item>
     </plurals>
+
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
+
     <string name="faq_1_title">How can I remove the holidays imported via the \"Add holidays\" button\?</string>
     <string name="faq_1_text">Holidays created that way are inserted in a new event type called \"Holidays\". You can go in Settings -&gt; Manage Event Types, long press the given event type and delete it by selecting the trashbin.</string>
     <string name="faq_2_title">Can I sync my events via Google Calendar, or other service supporting CalDAV\?</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -268,6 +268,11 @@
         <item quantity="many">W ciągu najbliższych %d miesięcy</item>
         <item quantity="other">W ciągu najbliższych %d miesięcy</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">Jak mogę usunąć święta zaimportowane przez przycisk „Dodaj święta”\?</string>
     <string name="faq_1_text">Święta dodane w ten sposób są wprowadzane do nowego typu wydarzeń — „Święta”. Możesz wejść w Ustawienia -&gt; Zarządzaj typami wydarzeń, a następnie przyciśnij długo dany typ wydarzeń i usuń go, wybierając ikonę kosza.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -265,6 +265,11 @@
         <item quantity="many">Nos próximos %d meses</item>
         <item quantity="other">Nos próximos %d meses</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">Como posso remover os feriados importados por meio do botão \"Adicionar feriados\"\?</string>
     <string name="faq_1_text">Os feriados criados dessa maneira são inseridos em um novo tipo de evento chamado \"Feriados \". Você pode ir em Configurações -&gt; Gerenciar tipos de eventos, pressione e segure o tipo de evento fornecido e exclua-o selecionando a lixeira.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -265,6 +265,11 @@
         <item quantity="many">Nos próximos %d meses</item>
         <item quantity="other">Nos próximos %d meses</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">Como posso remover os feriados que importei através do botão \"Adicionar feriados\"\?</string>
     <string name="faq_1_text">Os feriados criados assim são inseridos no novo tipo de evento chamado \"Feriados \". Em Definições -&gt; Gerir tipos de eventos, selecione o tipo de evento com um toque longo e enviando-o para o lixo.</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -265,6 +265,11 @@
         <item quantity="few">În următoarele %d luni</item>
         <item quantity="other">În următoarele %d de luni</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">Cum pot elimina sărbătorile importate prin intermediul butonului \"Adaugă sărbători\"\?</string>
     <string name="faq_1_text">Sărbătorile create îm felul acela sunt introduse într-un tip de event nou numit \"Sărbători\". Puteți să vă duceți în Setări -&gt; Gestionează tipurile de evenimente, apăsați lung tipul de eveniment dat și ștergeți-l selectând coșul de gunoi.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -268,6 +268,11 @@
         <item quantity="many">В течение следующих %d месяцев</item>
         <item quantity="other">В течение следующих %d месяцев</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">Как удалить праздники, импортированные с помощью кнопки \"Добавить праздники\"\?</string>
     <string name="faq_1_text">Праздники, созданные таким образом, вставляются в новый тип события, называемый \"Праздники\". Можно перейти в \"Настройки\" -&gt; \"Управление типами событий\", затем длительное нажатие на данном типе события и его удаление нажатием на \"корзину\".</string>

--- a/app/src/main/res/values-si/strings.xml
+++ b/app/src/main/res/values-si/strings.xml
@@ -283,6 +283,12 @@
         <item quantity="other">Within the next %d months</item>
     </plurals>
 
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
+
     <!-- FAQ -->
     <string name="faq_1_title">How can I remove the holidays imported via the \"Add holidays\" button?</string>
     <string name="faq_1_text">Holidays created that way are inserted in a new event type called \"Holidays\". You can go in Settings -> Manage Event Types,

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -265,6 +265,11 @@
         <item quantity="few">Najbližších %d mesiacov</item>
         <item quantity="other">Najbližších %d mesiacov</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">Ako môžem odstrániť sviatky pridané pomocou tlačidla \"Pridať sviatky\"\?</string>
     <string name="faq_1_text">Sviatky vytvorené daným spôsobom sú pridané do typu udalosti \"Sviatky\". Môžete teda ísť do Nastavenia -&gt; Spravovať typy udalostí, podržať daný typ a vymazať ho pomocou smetného koša.</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -268,6 +268,11 @@
         <item quantity="few">V naslednjih %d mesecih</item>
         <item quantity="other">V naslednjih %d mesecih</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">Kako lahko odstranim praznike, uvožene z gumbom \"Dodaj praznike\"\?</string>
     <string name="faq_1_text">Tako ustvarjeni prazniki se vstavijo v novo vrsto dogodka z imenom \"Prazniki\". V razdelku Nastavitve -&gt; Upravljanje tipov dogodkov lahko dolgo pritisnete na določen tip dogodka in ga izbrišete tako, da izberete koš za smeti.</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -265,6 +265,11 @@
         <item quantity="few">У наредна %d месеца</item>
         <item quantity="other">У наредних %d месеци</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">Како могу да уклоним празнике увезене преко дугмета „Додај празнике“\?</string>
     <string name="faq_1_text">Празници направљени на тај начин умећу се у нови тип догађаја под називом „Празници“. Можете да одете у Подешавања -&gt; Управљање типовима догађаја, дуго притисните дати тип догађаја и избришите га тако што ћете изабрати канту за смеће.</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -262,6 +262,11 @@
         <item quantity="one">Inom den kommande %d månaden</item>
         <item quantity="other">Inom de kommande %d månaderna</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">Hur kan jag ta bort helgdagar som importerats via knappen \"Lägg till helgdagar\"\?</string>
     <string name="faq_1_text">Helgdagar som skapas på detta sätt läggs in i en ny händelsetyp som kallas \"Helgdagar\". Du kan gå till Inställningar -&gt; Hantera händelsetyper, trycka länge på den aktuella händelsetypen och ta bort den genom att välja papperskorgen.</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -262,6 +262,11 @@
         <item quantity="one">Within the next %d month</item>
         <item quantity="other">Within the next %d months</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">How can I remove the holidays imported via the \"Add holidays\" button\?</string>
     <string name="faq_1_text">Holidays created that way are inserted in a new event type called \"Holidays\". You can go in Settings -&gt; Manage Event Types, long press the given event type and delete it by selecting the trashbin.</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -262,6 +262,11 @@
         <item quantity="one">Sonraki %d ay içinde</item>
         <item quantity="other">Sonraki %d ay içinde</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">\"Tatil ekle\" düğmesiyle içe aktarılan tatilleri nasıl kaldırabilirim\?</string>
     <string name="faq_1_text">Tatiller, \"Tatiller\" olarak adlandırılan yeni bir etkinlik türüne eklenir. Ayarlar -&gt; Etkinlik Türlerini Yönet\'e gidip, belirlenen etkinlik türüne uzun basıp çöp kutusunu seçerek silebilirsiniz.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -268,6 +268,11 @@
         <item quantity="many">Протягом наступних %d місяців</item>
         <item quantity="other">Протягом наступних %d місяців</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">Як видалити свята, імпортовані з допомогою кнопки \"Додати свята\"\?</string>
     <string name="faq_1_text">Свята, створені таким чином, групуються в новий тип подій, що називається \"Свята\". Можна перейти в \"Налаштування\" -&gt; \"Керувати типами подій\", потім тривале натиснення на даному типу подій активує процедуру видалення, нарешті натиснути \"Кошик\".</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -259,6 +259,11 @@
     <plurals name="within_the_next_months">
         <item quantity="other">在未来 %d 个月内</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">我如何移除用[添加节日]按钮所导入的节日\?</string>
     <string name="faq_1_text">以这方式建立的节日，会被加进一个叫做「节日」的新活动类型。 您可以到[设定] -&gt; [管理活动类型]，长按特定的活动类型，然后选择垃圾桶来删除。</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -259,6 +259,11 @@
     <plurals name="within_the_next_months">
         <item quantity="other">Within the next %d month</item>
     </plurals>
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
     <!-- FAQ -->
     <string name="faq_1_title">我如何移除用[添加節日]按鈕所匯入的節日\?</string>
     <string name="faq_1_text">以這方式建立的節日，會被加進一個叫做「節日」的新活動類型。 你可以到[設定] -&gt; [管理活動類型]，長按特定的活動類型，然後選擇垃圾桶來刪除。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -283,6 +283,12 @@
         <item quantity="other">在接下來的 %d 個月內</item>
     </plurals>
 
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
+
     <!-- FAQ -->
     <string name="faq_1_title">如何移除透過「新增節日」按鈕匯入的節日呢？</string>
     <string name="faq_1_text">以這方式建立的節日，會被新增到一個名為「節日」的新活動類型裡。你可以在「設定」-&gt;「管理活動類型」中，長按該活動類型，然後選擇垃圾桶圖示進行刪除。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -283,6 +283,12 @@
         <item quantity="other">Within the next %d months</item>
     </plurals>
 
+    <!-- Accessibility label -->
+    <string name="accessibility_previous_month">Go to previous month</string>
+    <string name="accessibility_next_month">Go to next month</string>
+    <string name="accessibility_previous_day">Go to previous day</string>
+    <string name="accessibility_next_day">Go to next day</string>
+
     <!-- FAQ -->
     <string name="faq_1_title">How can I remove the holidays imported via the \"Add holidays\" button?</string>
     <string name="faq_1_text">Holidays created that way are inserted in a new event type called \"Holidays\". You can go in Settings -> Manage Event Types,


### PR DESCRIPTION
I started working on integrating accessibility into the app ([Task#5](https://github.com/FossifyOrg/Calendar/issues/5)). This is the first in a series of several PRs.

What I did is to add the content description corresponding to the chevrons for the month and day fragments.
![moth2](https://github.com/FossifyOrg/Calendar/assets/34175360/8b875688-819e-4ebe-ab04-3eeddc2173c9)
(Example of chevron on which work was performed with active talkback)


I also added the corresponding strings in all the string files in app (as mentioned in the [guide for collaborations](https://github.com/FossifyOrg/General-Discussion#contribution-rules-for-developers)) The translation of the 4 strings i added is for all languages in English except Italian since that is my native language.
I did not add the strings in the recently added strings files for the new languages since the files are empty.