### PR TITLE
Add content description in calendar for each day

### DIFF
--- a/app/src/main/kotlin/org/fossify/calendar/views/MonthViewWrapper.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/views/MonthViewWrapper.kt
@@ -8,6 +8,7 @@ import org.fossify.calendar.databinding.MonthViewBackgroundBinding
 import org.fossify.calendar.databinding.MonthViewBinding
 import org.fossify.calendar.extensions.config
 import org.fossify.calendar.helpers.COLUMN_COUNT
+import org.fossify.calendar.helpers.Formatter
 import org.fossify.calendar.helpers.ROW_COUNT
 import org.fossify.calendar.models.DayMonthly
 import org.fossify.commons.extensions.onGlobalLayout
@@ -134,6 +135,8 @@ class MonthViewWrapper(context: Context, attrs: AttributeSet, defStyle: Int) : F
             if (isMonthDayView) {
                 background = null
             }
+            //Accessible label composed by day and month
+            contentDescription = "${day.value} ${Formatter.getMonthName(context,  Formatter.getDateTimeFromCode(day.code).monthOfYear)}"
 
             layoutParams.width = dayWidth.toInt()
             layoutParams.height = dayHeight.toInt()


### PR DESCRIPTION
Improvement related to the accessibility task: [Task#5](https://github.com/FossifyOrg/Calendar/issues/5).

What I did is to add the content description, composed by day and month, for each day in calendar.

![Cattura](https://github.com/FossifyOrg/Calendar/assets/34175360/91a2f037-06f0-4549-a4ed-f0ac99a3a89b)
(Example of calendar day on which work was performed with active talkback)