### PR TITLE
[L10n] Update MainActivity.kt: "Thailand": "ราชอาณาจักรไทย" -> "ไทย"

### DIFF
--- a/app/src/main/kotlin/org/fossify/calendar/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/activities/MainActivity.kt
@@ -1305,7 +1305,7 @@ class MainActivity : SimpleActivity(), RefreshRecyclerViewListener {
             put("Suomi", "finland.ics")
             put("Sverige", "sweden.ics")
             put("Taiwan", "taiwan.ics")
-            put("ราชอาณาจักรไทย", "thailand.ics")
+            put("ไทย", "thailand.ics")
             put("Türkiye Cumhuriyeti", "turkey.ics")
             put("Ukraine", "ukraine.ics")
             put("United Kingdom", "unitedkingdom.ics")


### PR DESCRIPTION
Use a normal form of the country name, not the full official.

This proposed translation ("ไทย") is the same as in latest Unicode Common Locale Data Repository version 44: http://unicode.org/Public/cldr/44/