### PR TITLE
Fix google pixel month view

### DIFF
--- a/app/src/main/kotlin/org/fossify/calendar/views/MonthViewWrapper.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/views/MonthViewWrapper.kt
@@ -74,7 +74,7 @@ class MonthViewWrapper(context: Context, attrs: AttributeSet, defStyle: Int) : F
 
             child.layout(childLeft.toInt(), childTop.toInt(), childRight.toInt(), childBottom.toInt())
 
-            if (curLeft + childWidth < end) {
+            if (curLeft + childWidth <= end) {
                 curLeft += childWidth
                 x++
             } else {
@@ -107,41 +107,29 @@ class MonthViewWrapper(context: Context, attrs: AttributeSet, defStyle: Int) : F
     }
 
     private fun measureSizes() {
-        dayWidth = (width - horizontalOffset) / 7f
-        dayHeight = (height - weekDaysLetterHeight) / 6f
+        dayWidth = (width - horizontalOffset) / COLUMN_COUNT.toFloat()
+        dayHeight = (height - weekDaysLetterHeight) / ROW_COUNT.toFloat()
     }
 
     private fun addClickableBackgrounds() {
         removeAllViews()
         binding = MonthViewBinding.inflate(inflater, this, true)
         wereViewsAdded = true
-        var curId = 0
-        for (y in 0 until ROW_COUNT) {
-            for (x in 0 until COLUMN_COUNT) {
-                val day = days.getOrNull(curId)
-                if (day != null) {
-                    addViewBackground(x, y, day)
-                }
-                curId++
-            }
+        days.forEachIndexed { index, day ->
+            addViewBackground(index % COLUMN_COUNT, index / COLUMN_COUNT, day)
         }
+
     }
 
     private fun addViewBackground(viewX: Int, viewY: Int, day: DayMonthly) {
-        val xPos = viewX * dayWidth + horizontalOffset
-        val yPos = viewY * dayHeight + weekDaysLetterHeight
 
         MonthViewBackgroundBinding.inflate(inflater, this, false).root.apply {
             if (isMonthDayView) {
                 background = null
             }
             //Accessible label composed by day and month
-            contentDescription = "${day.value} ${Formatter.getMonthName(context,  Formatter.getDateTimeFromCode(day.code).monthOfYear)}"
+            contentDescription = "${day.value} ${Formatter.getMonthName(context, Formatter.getDateTimeFromCode(day.code).monthOfYear)}"
 
-            layoutParams.width = dayWidth.toInt()
-            layoutParams.height = dayHeight.toInt()
-            x = xPos
-            y = yPos
             setOnClickListener {
                 dayClickCallback?.invoke(day)
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- The problem was that the screen width is exactly divisible by 7 (the number of days in one row/week), so in line 77 (where it was `<` instead of `<=`) it instead wrapped the last element always to the next line.
https://github.com/FossifyOrg/Calendar/blob/abd573cc43dacb5320eb09a35ae94ffad821b237/app/src/main/kotlin/org/fossify/calendar/views/MonthViewWrapper.kt#L77
- Removed redundant position calculations, as they are instantly altered by the onLayout function, so they are not even used. (can be reverted if not wanted, as these changes don't affect the bug fix)

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, consider including screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before:
As you can see the dates on the right don't have this bounding box which is clickable, and the boxes also went out of the visible area at the bottom.
![image](https://github.com/FossifyOrg/Calendar/assets/32615971/cfc746c7-c533-45d4-87b3-4898dc794f1a)

- After:
Now every date has a bounding box that is clickable and no boxes are below the visible area.
![image](https://github.com/FossifyOrg/Calendar/assets/32615971/853bac2d-8fd7-4474-bf09-6f5df270d541)


#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #7

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Calendar/blob/master/CONTRIBUTING.md).
