### PR TITLE
Bug fix : Remove Duplicating Event after changes

### DIFF
--- a/app/src/main/kotlin/org/fossify/calendar/activities/EventActivity.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/activities/EventActivity.kt
@@ -1375,6 +1375,7 @@ class EventActivity : SimpleActivity() {
                     eventsHelper.editSelectedOccurrence(mEvent, true) {
                         finish()
                     }
+                    eventsHelper.deleteRepeatingEventOccurrence(mEvent.id!!, mEventOccurrenceTS, true)
                 }
 
                 EDIT_FUTURE_OCCURRENCES -> {


### PR DESCRIPTION
#### What is it?
 
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
##### Application behavior before the bug was fixed : 

If you have a recurring event every week, but one week you decide to change this event to, say, the previous day, the previous event will not be deleted after you press "Update the selected occurence only".

##### Application behavior after the bug was fixed : 

Now it will.

#### Before/After Screenshots/Screen Record
Quick video showing the change, sorry for the poor quality but everything is understandable
https://github.com/FossifyOrg/Calendar/assets/72163995/eb4d0deb-5631-4841-b3a3-e739287978d2

#### Fixes the following issue(s)
- Fixes #138

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Calendar/blob/master/CONTRIBUTING.md).

PS : This is our first contribution, so don't hesitate to tell us if there's anything we need to improve.
