### PR TITLE
[Holiday generator] Generate all holidays in UTC

### DIFF
--- a/.github/workflows/holiday-generator/main.js
+++ b/.github/workflows/holiday-generator/main.js
@@ -28,6 +28,7 @@ function log(toLog) {
  */
 function getEvents(countryCode) {
     const generator = new Holidays(countryCode);
+    generator.setTimezone("UTC");
     const events = [];
     for (let i = START_YEAR; i <= END_YEAR; i++) {
         events.push(...generator.getHolidays(i).filter((x) => TYPE_WHITELIST.includes(x.type)));
@@ -54,7 +55,7 @@ function generateUid(countryCode, date, rule) {
  * @returns
  */
 function getDateArray(date) {
-    return [date.getFullYear(), date.getMonth() + 1, date.getDate()];
+    return [date.getUTCFullYear(), date.getUTCMonth() + 1, date.getUTCDate()];
 }
 
 /**
@@ -79,9 +80,9 @@ async function generateIcal(events, countryCode) {
         if (isFixedDate(x.rule)) {
             const uid = generateUid(countryCode, "", x.rule);
             if (!eventsMap.has(uid)) {
-                const yearDiff = x.end.getFullYear() - x.start.getFullYear();
-                x.start.setFullYear(FIXED_DATE_START_YEAR);
-                x.end.setFullYear(FIXED_DATE_START_YEAR + yearDiff);
+                const yearDiff = x.end.getUTCFullYear() - x.start.getUTCFullYear();
+                x.start.setUTCFullYear(FIXED_DATE_START_YEAR);
+                x.end.setUTCFullYear(FIXED_DATE_START_YEAR + yearDiff);
                 eventsMap.set(uid, {
                     title: x.name,
                     uid,


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [X] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
- Fixed wrong date generating in holiday generator (as reported in https://github.com/FossifyOrg/Calendar/pull/173).
- Now, regardless of the timezone where the script is run, it should always generate and read dates in UTC.

#### Before/After Screenshots/Screen Record
Not a screenshot, but here is a ZIP with three ICS files generated by the generator now. I've run it in GMT+1 and there are three different countries in three entirely different timezones - USA (probably ET which is GMT-5), Poland (GMT+1) and Australia (likely AEST which is GMT+10).
[holidays.zip](https://github.com/FossifyOrg/Calendar/files/14619112/holidays.zip).

As you can see, common holidays like Easter or Christmas are on the same day. I've imported them to Fossify Calendar and all were on the proper date, but I haven't changed the timezone of my phone to any not so close to UTC as mine, so I don't know if holidays imports correctly e.g. in the USA, but I don't see why they shouldn't

#### Acknowledgement
- [X] I read the [contribution guidelines](https://github.com/FossifyOrg/Calendar/blob/master/CONTRIBUTING.md).
