### PR TITLE
Bump fixed date holiday start year to 1980

### DIFF
--- a/.github/workflows/holiday-generator/config.js
+++ b/.github/workflows/holiday-generator/config.js
@@ -79,7 +79,7 @@ export const UNSUPPORTED_COUNTRIES = {
 
 export const START_YEAR = new Date().getFullYear(); // start with current year
 export const END_YEAR = START_YEAR + 1;
-export const FIXED_DATE_START_YEAR = 1970; // start recurring events from start of Unix epoch
+export const FIXED_DATE_START_YEAR = 1980; // start recurring events from start of Unix epoch
 
 // https://www.npmjs.com/package/date-holidays#types-of-holidays
 export const TYPE_PUBLIC = ["public", "bank"];


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR

For some unknown reason, sometimes, in some timezones, events like the "New Year's Day" are missing because their start date is 01/01/1970. This quick fix resolves this issue at least for holidays.

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Calendar/blob/master/CONTRIBUTING.md).
