### PR TITLE
Apply proper color to "Mark completed" button background

### DIFF
--- a/app/src/main/kotlin/org/fossify/calendar/activities/TaskActivity.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/activities/TaskActivity.kt
@@ -3,7 +3,6 @@ package org.fossify.calendar.activities
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
 import android.content.Intent
-import android.graphics.Color
 import android.os.Bundle
 import android.view.WindowManager
 import androidx.core.content.ContextCompat
@@ -648,18 +647,18 @@ class TaskActivity : SimpleActivity() {
     }
 
     private fun updateTaskCompletedButton() {
+        val primaryColor = getProperPrimaryColor()
         if (mTaskCompleted) {
-            binding.toggleMarkComplete.background = ContextCompat.getDrawable(this, org.fossify.commons.R.drawable.button_background_stroke)
+            binding.toggleMarkComplete.background = ContextCompat.getDrawable(
+                this, org.fossify.commons.R.drawable.button_background_stroke
+            )
             binding.toggleMarkComplete.setText(R.string.mark_incomplete)
             binding.toggleMarkComplete.setTextColor(getProperTextColor())
         } else {
-            val markCompleteBgColor = if (isWhiteTheme()) {
-                Color.WHITE
-            } else {
-                getProperPrimaryColor()
-            }
-            binding.toggleMarkComplete.setTextColor(markCompleteBgColor.getContrastColor())
+            binding.toggleMarkComplete.setTextColor(primaryColor.getContrastColor())
         }
+
+        binding.toggleMarkComplete.background.applyColorFilter(primaryColor)
     }
 
     private fun toggleCompletion() {


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
- Set "Mark completed" background color to primary

#### Before/After Screenshots/Screen Record
<img alt="Screenshot_20250124_234134_Calendar_debug" src="https://github.com/user-attachments/assets/633bad01-ef5f-4384-ba48-765e3a4dbcd9" width=184 />
<img alt="Screenshot_20250124_234440_Calendar_debug" src="https://github.com/user-attachments/assets/e7caa74b-5dbb-4602-922b-9a0a57925e0a" width=184 />     • 
<img alt="Screenshot_20250124_233956_Calendar_debug" src="https://github.com/user-attachments/assets/790164bb-4523-4d96-8b2f-4fe4183dbf1e" width=184 />
<img alt="Screenshot_20250124_234027_Calendar_debug" src="https://github.com/user-attachments/assets/45f7fc13-856f-473e-aa0b-55a46de7f680" width=184 />


#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #357

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Calendar/blob/master/CONTRIBUTING.md).
