### PR TITLE
Remove CalDAV event color modification

### DIFF
--- a/app/src/main/kotlin/org/fossify/calendar/helpers/CalDAVHelper.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/helpers/CalDAVHelper.kt
@@ -4,13 +4,37 @@ import android.annotation.SuppressLint
 import android.content.ContentUris
 import android.content.ContentValues
 import android.content.Context
-import android.provider.CalendarContract.*
+import android.provider.CalendarContract.Attendees
+import android.provider.CalendarContract.Calendars
+import android.provider.CalendarContract.Colors
+import android.provider.CalendarContract.Events
+import android.provider.CalendarContract.Reminders
 import android.widget.Toast
 import org.fossify.calendar.R
-import org.fossify.calendar.extensions.*
-import org.fossify.calendar.models.*
+import org.fossify.calendar.extensions.config
+import org.fossify.calendar.extensions.eventTypesDB
+import org.fossify.calendar.extensions.eventsDB
+import org.fossify.calendar.extensions.eventsHelper
+import org.fossify.calendar.extensions.queryCursorInlined
+import org.fossify.calendar.extensions.refreshCalDAVCalendars
+import org.fossify.calendar.extensions.scheduleCalDAVSync
+import org.fossify.calendar.extensions.toLocalAllDayEvent
+import org.fossify.calendar.extensions.toUtcAllDayEvent
+import org.fossify.calendar.models.Attendee
+import org.fossify.calendar.models.CalDAVCalendar
+import org.fossify.calendar.models.Event
+import org.fossify.calendar.models.EventType
+import org.fossify.calendar.models.Reminder
 import org.fossify.calendar.objects.States.isUpdatingCalDAV
-import org.fossify.commons.extensions.*
+import org.fossify.commons.extensions.areDigitsOnly
+import org.fossify.commons.extensions.getIntValue
+import org.fossify.commons.extensions.getIntValueOrNull
+import org.fossify.commons.extensions.getLongValue
+import org.fossify.commons.extensions.getStringValue
+import org.fossify.commons.extensions.hasPermission
+import org.fossify.commons.extensions.queryCursor
+import org.fossify.commons.extensions.showErrorToast
+import org.fossify.commons.extensions.toast
 import org.fossify.commons.helpers.PERMISSION_READ_CALENDAR
 import org.fossify.commons.helpers.PERMISSION_WRITE_CALENDAR
 import org.joda.time.DateTimeZone
@@ -28,9 +52,11 @@ class CalDAVHelper(val context: Context) {
 
         isUpdatingCalDAV = true
         try {
-            val calDAVCalendars = getCalDAVCalendars(context.config.caldavSyncedCalendarIds, showToasts)
+            val calDAVCalendars =
+                getCalDAVCalendars(context.config.caldavSyncedCalendarIds, showToasts)
             for (calendar in calDAVCalendars) {
-                val localEventType = eventsHelper.getEventTypeWithCalDAVCalendarId(calendar.id) ?: continue
+                val localEventType =
+                    eventsHelper.getEventTypeWithCalDAVCalendarId(calendar.id) ?: continue
                 if (calendar.displayName != localEventType.title || calendar.color != localEventType.color) {
                     localEventType.apply {
                         title = calendar.displayName
@@ -57,7 +83,10 @@ class CalDAVHelper(val context: Context) {
     @SuppressLint("MissingPermission")
     fun getCalDAVCalendars(ids: String, showToasts: Boolean): ArrayList<CalDAVCalendar> {
         val calendars = ArrayList<CalDAVCalendar>()
-        if (!context.hasPermission(PERMISSION_WRITE_CALENDAR) || !context.hasPermission(PERMISSION_READ_CALENDAR)) {
+        if (
+            !context.hasPermission(PERMISSION_WRITE_CALENDAR) ||
+            !context.hasPermission(PERMISSION_READ_CALENDAR)
+        ) {
             return calendars
         }
 
@@ -74,22 +103,25 @@ class CalDAVHelper(val context: Context) {
 
         val selection = if (ids.trim().isNotEmpty()) "${Calendars._ID} IN ($ids)" else null
         context.queryCursor(uri, projection, selection, showErrors = showToasts) { cursor ->
-            val id = cursor.getIntValue(Calendars._ID)
-            val displayName = cursor.getStringValue(Calendars.CALENDAR_DISPLAY_NAME)
-            val accountName = cursor.getStringValue(Calendars.ACCOUNT_NAME)
-            val accountType = cursor.getStringValue(Calendars.ACCOUNT_TYPE)
-            val ownerName = cursor.getStringValue(Calendars.OWNER_ACCOUNT) ?: ""
-            val color = cursor.getIntValue(Calendars.CALENDAR_COLOR)
-            val accessLevel = cursor.getIntValue(Calendars.CALENDAR_ACCESS_LEVEL)
-            val calendar = CalDAVCalendar(id, displayName, accountName, accountType, ownerName, color, accessLevel)
-            calendars.add(calendar)
+            calendars.add(
+                CalDAVCalendar(
+                    id = cursor.getIntValue(Calendars._ID),
+                    displayName = cursor.getStringValue(Calendars.CALENDAR_DISPLAY_NAME),
+                    accountName = cursor.getStringValue(Calendars.ACCOUNT_NAME),
+                    accountType = cursor.getStringValue(Calendars.ACCOUNT_TYPE),
+                    ownerName = cursor.getStringValue(Calendars.OWNER_ACCOUNT) ?: "",
+                    color = cursor.getIntValue(Calendars.CALENDAR_COLOR),
+                    accessLevel = cursor.getIntValue(Calendars.CALENDAR_ACCESS_LEVEL)
+                )
+            )
         }
 
         return calendars
     }
 
     fun updateCalDAVCalendar(eventType: EventType) {
-        val uri = ContentUris.withAppendedId(Calendars.CONTENT_URI, eventType.caldavCalendarId.toLong())
+        val uri =
+            ContentUris.withAppendedId(Calendars.CONTENT_URI, eventType.caldavCalendarId.toLong())
         val values = ContentValues().apply {
             val colorKey = getCalDAVColorKey(eventType)
             if (colorKey != null) {
@@ -104,7 +136,7 @@ class CalDAVHelper(val context: Context) {
         try {
             context.contentResolver.update(uri, values, null, null)
             context.eventTypesDB.insertOrUpdate(eventType)
-        } catch (e: IllegalArgumentException) {
+        } catch (_: IllegalArgumentException) {
         } catch (e: SecurityException) {
             context.showErrorToast(e)
         }
@@ -116,7 +148,10 @@ class CalDAVHelper(val context: Context) {
     }
 
     @SuppressLint("MissingPermission")
-    fun getAvailableCalDAVCalendarColors(eventType: EventType, colorType: Int = Colors.TYPE_CALENDAR): Map<Int, String> {
+    fun getAvailableCalDAVCalendarColors(
+        eventType: EventType,
+        colorType: Int = Colors.TYPE_CALENDAR,
+    ): Map<Int, String> {
         val colors = mutableMapOf<Int, String>()
         val uri = Colors.CONTENT_URI
         val projection = arrayOf(Colors.COLOR, Colors.COLOR_KEY)
@@ -132,7 +167,11 @@ class CalDAVHelper(val context: Context) {
     }
 
     @SuppressLint("MissingPermission")
-    private fun fetchCalDAVCalendarEvents(calendar: CalDAVCalendar, eventTypeId: Long, showToasts: Boolean) {
+    private fun fetchCalDAVCalendarEvents(
+        calendar: CalDAVCalendar,
+        eventTypeId: Long,
+        showToasts: Boolean,
+    ) {
         val calendarId = calendar.id
 
         val importIdsMap = HashMap<String, Event>()
@@ -183,7 +222,10 @@ class CalDAVHelper(val context: Context) {
             val title = cursor.getStringValue(Events.TITLE) ?: ""
 
             if (errorFetchingLocalEvents) {
-                context.toast(context.getString(R.string.fetching_event_failed, "\"$title\""), Toast.LENGTH_LONG)
+                context.toast(
+                    context.getString(R.string.fetching_event_failed, "\"$title\""),
+                    Toast.LENGTH_LONG
+                )
                 return
             }
 
@@ -216,12 +258,31 @@ class CalDAVHelper(val context: Context) {
             val source = "$CALDAV-$calendarId"
             val repeatRule = Parser().parseRepeatInterval(rrule, startTS)
             val event = Event(
-                null, startTS, endTS, title, location, description, reminder1?.minutes ?: REMINDER_OFF,
-                reminder2?.minutes ?: REMINDER_OFF, reminder3?.minutes ?: REMINDER_OFF,
-                reminder1?.type ?: REMINDER_NOTIFICATION, reminder2?.type ?: REMINDER_NOTIFICATION,
-                reminder3?.type ?: REMINDER_NOTIFICATION, repeatRule.repeatInterval, repeatRule.repeatRule,
-                repeatRule.repeatLimit, ArrayList(), attendees, importId, eventTimeZone, allDay, eventTypeId,
-                source = source, availability = availability, color = color, status = status
+                id = null,
+                startTS = startTS,
+                endTS = endTS,
+                title = title,
+                location = location,
+                description = description,
+                reminder1Minutes = reminder1?.minutes ?: REMINDER_OFF,
+                reminder2Minutes = reminder2?.minutes ?: REMINDER_OFF,
+                reminder3Minutes = reminder3?.minutes ?: REMINDER_OFF,
+                reminder1Type = reminder1?.type ?: REMINDER_NOTIFICATION,
+                reminder2Type = reminder2?.type ?: REMINDER_NOTIFICATION,
+                reminder3Type = reminder3?.type ?: REMINDER_NOTIFICATION,
+                repeatInterval = repeatRule.repeatInterval,
+                repeatRule = repeatRule.repeatRule,
+                repeatLimit = repeatRule.repeatLimit,
+                repetitionExceptions = ArrayList(),
+                attendees = attendees,
+                importId = importId,
+                timeZone = eventTimeZone,
+                flags = allDay,
+                eventType = eventTypeId,
+                source = source,
+                availability = availability,
+                color = color,
+                status = status
             )
 
             if (event.getIsAllDay()) {
@@ -239,7 +300,12 @@ class CalDAVHelper(val context: Context) {
                     // add this event to the parent event's list of exceptions
                     if (!parentEvent.repetitionExceptions.contains(originalDayCode)) {
                         parentEvent.addRepetitionException(originalDayCode)
-                        eventsHelper.insertEvent(parentEvent, addToCalDAV = false, showToasts = false, enableEventType = false)
+                        eventsHelper.insertEvent(
+                            event = parentEvent,
+                            addToCalDAV = false,
+                            showToasts = false,
+                            enableEventType = false
+                        )
                     }
 
                     // store the event in the local db only if it is an occurrence that has been modified and not deleted
@@ -249,7 +315,12 @@ class CalDAVHelper(val context: Context) {
                             event.id = storedEventId
                         }
                         event.parentId = parentEvent.id!!
-                        eventsHelper.insertEvent(event, addToCalDAV = false, showToasts = false, enableEventType = false)
+                        eventsHelper.insertEvent(
+                            event = event,
+                            addToCalDAV = false,
+                            showToasts = false,
+                            enableEventType = false
+                        )
                     } else {
                         // delete the deleted exception event from local db
                         val storedEventId = context.eventsDB.getEventIdWithImportId(importId)
@@ -273,7 +344,8 @@ class CalDAVHelper(val context: Context) {
                         if (it.endsWith("Z")) {
                             // convert for example "20190216T230000Z" to "20190217000000" in Slovakia in a weird way
                             val formatter = DateTimeFormat.forPattern("yyyyMMdd'T'HHmmss'Z'")
-                            val offset = DateTimeZone.getDefault().getOffset(System.currentTimeMillis())
+                            val offset =
+                                DateTimeZone.getDefault().getOffset(System.currentTimeMillis())
                             val dt = formatter.parseDateTime(it).plusMillis(offset)
                             val dayCode = Formatter.getDayCodeFromDateTime(dt)
                             event.addRepetitionException(dayCode)
@@ -299,12 +371,22 @@ class CalDAVHelper(val context: Context) {
 
                 if (existingEvent.hashCode() != event.hashCode() && title.isNotEmpty()) {
                     event.id = originalEventId
-                    eventsHelper.updateEvent(event, updateAtCalDAV = false, showToasts = false, enableEventType = false)
+                    eventsHelper.updateEvent(
+                        event = event,
+                        updateAtCalDAV = false,
+                        showToasts = false,
+                        enableEventType = false
+                    )
                 }
             } else {
                 if (title.isNotEmpty()) {
                     importIdsMap[event.importId] = event
-                    eventsHelper.insertEvent(event, addToCalDAV = false, showToasts = false, enableEventType = false)
+                    eventsHelper.insertEvent(
+                        event = event,
+                        addToCalDAV = false,
+                        showToasts = false,
+                        enableEventType = false
+                    )
                 }
             }
         }
@@ -358,7 +440,10 @@ class CalDAVHelper(val context: Context) {
         event.getReminders().forEach {
             val contentValues = ContentValues().apply {
                 put(Reminders.MINUTES, it.minutes)
-                put(Reminders.METHOD, if (it.type == REMINDER_EMAIL) Reminders.METHOD_EMAIL else Reminders.METHOD_ALERT)
+                put(
+                    Reminders.METHOD,
+                    if (it.type == REMINDER_EMAIL) Reminders.METHOD_EMAIL else Reminders.METHOD_ALERT
+                )
                 put(Reminders.EVENT_ID, event.getCalDAVEventId())
             }
 
@@ -390,7 +475,11 @@ class CalDAVHelper(val context: Context) {
     }
 
     private fun setupCalDAVEventImportId(event: Event) {
-        context.eventsDB.updateEventImportIdAndSource(event.importId, "$CALDAV-${event.getCalDAVCalendarId()}", event.id!!)
+        context.eventsDB.updateEventImportIdAndSource(
+            importId = event.importId,
+            source = "$CALDAV-${event.getCalDAVCalendarId()}",
+            id = event.id!!
+        )
     }
 
     private fun fillEventContentValues(event: Event): ContentValues {
@@ -478,7 +567,8 @@ class CalDAVHelper(val context: Context) {
     }
 
     fun deleteCalDAVCalendarEvents(calendarId: Long) {
-        val eventIds = context.eventsDB.getCalDAVCalendarEvents("$CALDAV-$calendarId").toMutableList()
+        val eventIds =
+            context.eventsDB.getCalDAVCalendarEvents("$CALDAV-$calendarId").toMutableList()
         eventsHelper.deleteEvents(eventIds, false)
     }
 
@@ -503,7 +593,10 @@ class CalDAVHelper(val context: Context) {
         }
     }
 
-    private fun fillEventRepeatExceptionValues(parentEvent: Event, occurrenceTS: Long): ContentValues {
+    private fun fillEventRepeatExceptionValues(
+        parentEvent: Event,
+        occurrenceTS: Long,
+    ): ContentValues {
         val isAllDay = parentEvent.getIsAllDay()
         val startMillis = if (isAllDay) {
             // original instance time must be in UTC since the parent event is an all-day event thus everything is handled in UTC
@@ -541,7 +634,8 @@ class CalDAVHelper(val context: Context) {
             val minutes = cursor.getIntValue(Reminders.MINUTES)
             val method = cursor.getIntValue(Reminders.METHOD)
             if (method == Reminders.METHOD_ALERT || method == Reminders.METHOD_EMAIL) {
-                val type = if (method == Reminders.METHOD_EMAIL) REMINDER_EMAIL else REMINDER_NOTIFICATION
+                val type =
+                    if (method == Reminders.METHOD_EMAIL) REMINDER_EMAIL else REMINDER_NOTIFICATION
                 val reminder = Reminder(minutes, type)
                 reminders.add(reminder)
             }
@@ -561,18 +655,28 @@ class CalDAVHelper(val context: Context) {
         )
         val selection = "${Attendees.EVENT_ID} = $eventId"
         context.queryCursor(uri, projection, selection) { cursor ->
-            val name = cursor.getStringValue(Attendees.ATTENDEE_NAME) ?: ""
             val email = cursor.getStringValue(Attendees.ATTENDEE_EMAIL) ?: ""
-            val status = cursor.getIntValue(Attendees.ATTENDEE_STATUS)
-            val relationship = cursor.getIntValue(Attendees.ATTENDEE_RELATIONSHIP)
-            val attendee = Attendee(0, name, email, status, "", email == calendar.ownerName, relationship)
+            val attendee =
+                Attendee(
+                    contactId = 0,
+                    name = cursor.getStringValue(Attendees.ATTENDEE_NAME) ?: "",
+                    email = email,
+                    status = cursor.getIntValue(Attendees.ATTENDEE_STATUS),
+                    photoUri = "",
+                    isMe = email == calendar.ownerName,
+                    relationship = cursor.getIntValue(Attendees.ATTENDEE_RELATIONSHIP)
+                )
             attendees.add(attendee)
         }
 
         return attendees
     }
 
-    private fun getCalDAVEventImportId(calendarId: Int, eventId: Long) = "$CALDAV-$calendarId-$eventId"
+    private fun getCalDAVEventImportId(calendarId: Int, eventId: Long): String {
+        return "$CALDAV-$calendarId-$eventId"
+    }
 
-    private fun refreshCalDAVCalendar(event: Event) = context.refreshCalDAVCalendars(event.getCalDAVCalendarId().toString(), false)
+    private fun refreshCalDAVCalendar(event: Event) {
+        context.refreshCalDAVCalendars(event.getCalDAVCalendarId().toString(), false)
+    }
 }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
Previously the app modified the event colors for proper contrast ratio directly at synchronization meaning the original event colors were never saved in the app's DB. This is not necessary because the app already handles contrast ratio at the UI level. 

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- This might be the reason for https://github.com/FossifyOrg/Calendar/issues/202 though I couldn't reproduce it.
- See also:
   - https://github.com/FossifyOrg/Calendar/issues/188
   - https://github.com/FossifyOrg/Calendar/pull/421#issuecomment-2600966222

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Calendar/blob/master/CONTRIBUTING.md).
