### PR TITLE
Fixed reverting old filtering on quick filter long press

### DIFF
--- a/app/src/main/kotlin/org/fossify/calendar/adapters/QuickFilterEventTypeAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/adapters/QuickFilterEventTypeAdapter.kt
@@ -38,9 +38,11 @@ class QuickFilterEventTypeAdapter(
                 .firstOrNull { eventType -> eventType.id.toString() == quickFilterEventType }
                 ?: return@forEach
             quickFilterEventTypes.add(eventType)
+        }
 
-            if (displayEventTypes.contains(eventType.id.toString())) {
-                activeKeys.add(eventType.id!!)
+        allEventTypes.forEach {
+            if (displayEventTypes.contains(it.id.toString())) {
+                activeKeys.add(it.id!!)
             }
         }
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
- Long press feature added in #314 isn't reverting event types that aren't shown on the quick filter bar. 
- This PR fixes it - on the second long press it reverts the filtering according to the filter popup, not according to the quick filter bar.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, consider including screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before:

https://github.com/user-attachments/assets/f3144c84-23da-464b-b3e2-1e26229ffee7

- After:

https://github.com/user-attachments/assets/662d4b22-f990-449c-9b7d-2ef5753c3ec1

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Calendar/blob/master/CONTRIBUTING.md).
