### PR TITLE
Fix calendar handling of pre-1970 birthdates

### DIFF
--- a/app/src/main/kotlin/org/fossify/calendar/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/activities/MainActivity.kt
@@ -914,11 +914,19 @@ class MainActivity : SimpleActivity(), RefreshRecyclerViewListener {
             contacts.forEach { contact ->
                 val events = if (birthdays) contact.birthdays else contact.anniversaries
                 events.forEach { birthdayAnniversary ->
+                    var missingYear = false
                     // private contacts are created in Simple Contacts Pro, so we can guarantee that they exist only in these 2 formats
                     val format = if (birthdayAnniversary.startsWith("--")) {
+                        missingYear = true
                         "--MM-dd"
                     } else {
                         "yyyy-MM-dd"
+                    }
+
+                    var flags = if (missingYear) {
+                        FLAG_ALL_DAY or FLAG_MISSING_YEAR
+                    } else {
+                        FLAG_ALL_DAY
                     }
 
                     val formatter = SimpleDateFormat(format, Locale.getDefault())
@@ -928,7 +936,7 @@ class MainActivity : SimpleActivity(), RefreshRecyclerViewListener {
                     val lastUpdated = System.currentTimeMillis()
                     val event = Event(
                         null, timestamp, timestamp, contact.name, reminder1Minutes = reminders[0], reminder2Minutes = reminders[1],
-                        reminder3Minutes = reminders[2], importId = contact.contactId.toString(), timeZone = DateTimeZone.getDefault().id, flags = FLAG_ALL_DAY,
+                        reminder3Minutes = reminders[2], importId = contact.contactId.toString(), timeZone = DateTimeZone.getDefault().id, flags = flags,
                         repeatInterval = YEAR, repeatRule = REPEAT_SAME_DAY, eventType = eventTypeId, source = source, lastUpdated = lastUpdated
                     )
 

--- a/app/src/main/kotlin/org/fossify/calendar/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/activities/MainActivity.kt
@@ -923,9 +923,6 @@ class MainActivity : SimpleActivity(), RefreshRecyclerViewListener {
 
                     val formatter = SimpleDateFormat(format, Locale.getDefault())
                     val date = formatter.parse(birthdayAnniversary)
-                    if (date.year < 70) {
-                        date.year = 70
-                    }
 
                     val timestamp = date.time / 1000L
                     val lastUpdated = System.currentTimeMillis()


### PR DESCRIPTION
Re submit PR #224, all credits to @TristanDonze.

I cannot do a build right now, but I can more than happily test a beta build if needed (and update the PR with any necessary changes if required, of course).

<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- Removed code related to a hard limit (1970) for private events;
- Add proper handling of private events with dates without year.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, consider including screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Please refer to #224 

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #196

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Calendar/blob/master/CONTRIBUTING.md).
