### PR TITLE
Fixed issue #376

### DIFF
--- a/app/src/main/res/layout-land/fragment_year.xml
+++ b/app/src/main/res/layout-land/fragment_year.xml
@@ -11,9 +11,9 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_below="@+id/top_left_arrow"
-        android:columnCount="4"
+        android:columnCount="6"
         android:padding="@dimen/yearly_padding_side"
-        android:rowCount="3">
+        android:rowCount="2">
 
         <include
             android:id="@+id/month_1_holder"


### PR DESCRIPTION
Gridlayout now has columncount of 6 instead of 4 for months.

<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
Modified number of months that can be held in one line from 4 to 6 in yearly view gridlayout

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, consider including screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before:
![Screenshot_20250220_162100](https://github.com/user-attachments/assets/d85a027f-3f78-4974-9722-5bb9b71497db)

- After: 
![Screenshot_20250220_161914](https://github.com/user-attachments/assets/5b168de4-eb86-4589-9c5f-32f527d7d1d8)


#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #376 

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Calendar/blob/master/CONTRIBUTING.md).
