### PR TITLE
Add default timezone to IcsImporter for timestamps not ending in Z (UTC)

### DIFF
--- a/app/src/main/kotlin/org/fossify/calendar/helpers/IcsImporter.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/helpers/IcsImporter.kt
@@ -393,11 +393,11 @@ class IcsImporter(val activity: SimpleActivity) {
 
     private fun getTimestamp(fullString: String): Long {
         return try {
+            var timeZone = DateTimeZone.getDefault()
             when {
                 fullString.startsWith(';') -> {
                     // Ideally, we should parse BEGIN:VTIMEZONE and derive the timezone from there, but to get things working, let's assume TZID refers to one
                     // of the known timezones
-                    var timeZone = DateTimeZone.getDefault()
                     if (fullString.contains(':')) {
                         val timeZoneId = fullString.substringAfter("%s=".format(TZID)).substringBefore(':')
                         if (DateTimeZone.getAvailableIDs().contains(timeZoneId)) {
@@ -415,7 +415,8 @@ class IcsImporter(val activity: SimpleActivity) {
                     Parser().parseDateTimeValue(value, timeZone)
                 }
 
-                fullString.startsWith(":") -> Parser().parseDateTimeValue(fullString.substring(1).trim())
+                fullString.startsWith(":") -> Parser().parseDateTimeValue(fullString.substring(1).trim(), timeZone)
+
                 else -> Parser().parseDateTimeValue(fullString)
             }
         } catch (e: Exception) {


### PR DESCRIPTION
#### What is it?
- [X] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
- Updated IcsImporter.kt to apply local timezone to events with timestamps not ending in Z (UTC time)

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #262

#### Acknowledgement
- [X] I read the [contribution guidelines](https://github.com/FossifyOrg/Calendar/blob/master/CONTRIBUTING.md).
