### PR TITLE
Add Bangladesh to holiday-generator config

### DIFF
--- a/.github/workflows/holiday-generator/config.js
+++ b/.github/workflows/holiday-generator/config.js
@@ -12,6 +12,7 @@ export const COUNTRIES = [
     "AR", // Argentina
     "AU", // Australia
     "AT", // Austria
+    "BD", // Bangladesh
     "BE", // Belgium
     "BO", // Bolivia
     "BR", // Brazil


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [ ] Bugfix
- [x] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- Bangladesh is in the supported country list of `date-holidays` library but it was not included in our holiday-generator config.


#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Calendar/blob/master/CONTRIBUTING.md).
