### PR TITLE
fix: use direct anchor for access level divider

### DIFF
--- a/app/src/main/res/layout/activity_event.xml
+++ b/app/src/main/res/layout/activity_event.xml
@@ -534,7 +534,7 @@
                 android:id="@+id/event_access_level_divider"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/divider_height"
-                android:layout_below="@+id/event_access_level_image"
+                android:layout_below="@+id/event_access_level"
                 android:layout_marginTop="@dimen/medium_margin"
                 android:background="@color/divider_grey"
                 android:importantForAccessibility="no" />


### PR DESCRIPTION
#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
Adjusted the anchor for `event_access_level_divider` from `event_access_level_image` to `event_access_level`.

This prevents views positioned below the access level section from jumping to the top when the access level section is hidden.

#### Before/After Screenshots/Screen Record

<img alt="image" src="https://github.com/user-attachments/assets/4dca1d84-3cb5-490b-955a-d5289ddf82c1" width=181 />
<img alt="image" src="https://github.com/user-attachments/assets/47e45a30-fa13-4afd-ae28-2dc9649bb5c6" width=181 />

#### Fixes the following issue(s)
- Not tracked. Caused by: https://github.com/FossifyOrg/Calendar/pull/490

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Calendar/blob/master/CONTRIBUTING.md).
