### PR TITLE
FIxed Go to today in Weekly view (#551)

### DIFF
--- a/app/src/main/kotlin/org/fossify/calendar/fragments/WeekFragmentsHolder.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/fragments/WeekFragmentsHolder.kt
@@ -44,7 +44,7 @@ class WeekFragmentsHolder : MyFragmentHolder(), WeekFragmentListener {
         super.onCreate(savedInstanceState)
         val dateTimeString = arguments?.getString(WEEK_START_DATE_TIME) ?: return
         currentWeekTS = (DateTime.parse(dateTimeString) ?: DateTime()).seconds()
-        thisWeekTS = DateTime.parse(requireContext().getFirstDayOfWeek(DateTime())).seconds()
+        updateThisWeekTS()
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
@@ -214,12 +214,22 @@ class WeekFragmentsHolder : MyFragmentHolder(), WeekFragmentListener {
 
     private fun updateWeeklyViewDays(days: Int) {
         requireContext().config.weeklyViewDays = days
+        updateThisWeekTS()
+        updateCurrentWeekTS()
         updateDaysCount(days)
         setupWeeklyViewPager()
     }
 
     private fun updateDaysCount(cnt: Int) {
         binding.weekViewDaysCount.text = requireContext().resources.getQuantityString(org.fossify.commons.R.plurals.days, cnt, cnt)
+    }
+
+    private fun updateThisWeekTS() {
+        thisWeekTS = DateTime.parse(requireContext().getFirstDayOfWeek(DateTime())).seconds()
+    }
+
+    private fun updateCurrentWeekTS() {
+        currentWeekTS = DateTime.parse(requireContext().getFirstDayOfWeek(DateTime(currentWeekTS * 1000))).seconds()
     }
 
     override fun refreshEvents() {


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- Modified `getFirstDayOfWeekDt`:
    - Considering the `weeklyViewDays` setting if it's lower than 7.
    - Refactored code to have only one return, so it has a better readability with more conditions.
- Modified `WeekFragmentsHolder` to correctly handle updating `thisWeekTS` and `currentWeekTS` according to the `weeklyViewDays` value.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, consider including screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before:

https://github.com/user-attachments/assets/b33c3aba-01e2-4036-865c-81c2784b3ac8

- After:

https://github.com/user-attachments/assets/58980ce4-9080-470f-984d-d531f3361fa9

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #551 

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Calendar/blob/master/CONTRIBUTING.md).
