### PR TITLE
fix: avoid notifying for declined events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Declined events no longer trigger notifications ([#732])
+
 ## [1.6.0] - 2025-08-21
 ### Added
 - Holidays for Philippines ([#729])
@@ -121,6 +124,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#613]: https://github.com/FossifyOrg/Calendar/issues/613
 [#682]: https://github.com/FossifyOrg/Calendar/issues/682
 [#729]: https://github.com/FossifyOrg/Calendar/issues/729
+[#732]: https://github.com/FossifyOrg/Calendar/issues/732
 
 [Unreleased]: https://github.com/FossifyOrg/Calendar/compare/1.6.0...HEAD
 [1.6.0]: https://github.com/FossifyOrg/Calendar/compare/1.5.0...1.6.0

--- a/app/src/main/kotlin/org/fossify/calendar/extensions/Context.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/extensions/Context.kt
@@ -377,6 +377,7 @@ fun Context.getRepetitionText(seconds: Int) = when (seconds) {
 
 fun Context.notifyRunningEvents() {
     eventsHelper.getRunningEventsOrTasks()
+        .filter { !it.isAttendeeInviteDeclined() }
         .filter { it.getReminders().any { reminder -> reminder.type == REMINDER_NOTIFICATION } }
         .forEach {
             notifyEvent(it)


### PR DESCRIPTION
Closes #732

<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
When I decline an invitation to a meeting, a reminder that it's starting is a bit irrelevant and confusing. I think it makes sense to exclude these from notifications, mirroring the behavior of the Google Calendar app.

#### Before & after preview
<!-- For changes affecting UI, consider attaching screenshots or a video. Delete this section otherwise. -->
_No UI changes_

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable). _I can't currently reproduce this on my own, since I need to decline a meeting that someone else invited me to_
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
