### PR TITLE
fix: improve event scheduling logic on reboot

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -281,14 +281,16 @@
             android:exported="false" />
 
         <receiver
-            android:name=".receivers.BootCompletedReceiver"
+            android:name=".receivers.RescheduleEventsReceiver"
             android:exported="true">
 
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
-                <action android:name="android.intent.action.QUICKBOOT_POWERON" />
-                <action android:name="com.htc.intent.action.QUICKBOOT_POWERON" />
                 <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+                <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+                <action android:name="android.intent.action.TIMEZONE_CHANGED" />
+                <action android:name="android.intent.action.TIME_SET" />
+                <action android:name="com.htc.intent.action.QUICKBOOT_POWERON" />
             </intent-filter>
         </receiver>
 

--- a/app/src/main/kotlin/org/fossify/calendar/receivers/BootCompletedReceiver.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/receivers/BootCompletedReceiver.kt
@@ -1,14 +1,21 @@
 package org.fossify.calendar.receivers
 
+import android.annotation.SuppressLint
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import org.fossify.calendar.extensions.*
+import org.fossify.calendar.extensions.checkAndBackupEventsOnBoot
+import org.fossify.calendar.extensions.notifyRunningEvents
+import org.fossify.calendar.extensions.recheckCalDAVCalendars
+import org.fossify.calendar.extensions.scheduleAllEvents
+import org.fossify.calendar.extensions.scheduleNextAutomaticBackup
 import org.fossify.commons.helpers.ensureBackgroundThread
 
 class BootCompletedReceiver : BroadcastReceiver() {
 
+    @SuppressLint("UnsafeProtectedBroadcastReceiver")
     override fun onReceive(context: Context, intent: Intent) {
+        val pendingResult = goAsync()
         ensureBackgroundThread {
             context.apply {
                 scheduleAllEvents()
@@ -16,6 +23,7 @@ class BootCompletedReceiver : BroadcastReceiver() {
                 recheckCalDAVCalendars(true) {}
                 scheduleNextAutomaticBackup()
                 checkAndBackupEventsOnBoot()
+                pendingResult.finish()
             }
         }
     }

--- a/app/src/main/kotlin/org/fossify/calendar/receivers/BootCompletedReceiver.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/receivers/BootCompletedReceiver.kt
@@ -15,7 +15,7 @@ class BootCompletedReceiver : BroadcastReceiver() {
 
     @SuppressLint("UnsafeProtectedBroadcastReceiver")
     override fun onReceive(context: Context, intent: Intent) {
-        val pendingResult = goAsync()
+        val pendingResult = goAsync() // TO DO: switch to WorkManager for more resilence
         ensureBackgroundThread {
             context.apply {
                 scheduleAllEvents()

--- a/app/src/main/kotlin/org/fossify/calendar/receivers/RescheduleEventsReceiver.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/receivers/RescheduleEventsReceiver.kt
@@ -11,7 +11,7 @@ import org.fossify.calendar.extensions.scheduleAllEvents
 import org.fossify.calendar.extensions.scheduleNextAutomaticBackup
 import org.fossify.commons.helpers.ensureBackgroundThread
 
-class BootCompletedReceiver : BroadcastReceiver() {
+class RescheduleEventsReceiver : BroadcastReceiver() {
 
     @SuppressLint("UnsafeProtectedBroadcastReceiver")
     override fun onReceive(context: Context, intent: Intent) {


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Added call to goAsync() before doing background work in receiver (switching to WorkManager soon).
- Dropped `canScheduleExactAlarm()` check for Android 13+. 
- Added two more triggers for BootCompletedReceiver:
	- `android.intent.action.TIMEZONE_CHANGED`
	- `android.intent.action.TIME_SET` 
- Renamed BootCompletedReceiver to RescheduleEventsReceiver.

More details in commits messages.

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Calendar/issues/217

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [ ] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [ ] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
