### PR TITLE
fix: request exact alarm permission on Android 12 when revoked

### DIFF
--- a/app/src/main/kotlin/org/fossify/calendar/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/activities/MainActivity.kt
@@ -239,6 +239,8 @@ class MainActivity : SimpleActivity(), RefreshRecyclerViewListener {
         addImportIdsToTasks {
             refreshViewPager()
         }
+
+        maybeRequestExactAlarmPermission()
     }
 
     override fun onResume() {

--- a/app/src/main/kotlin/org/fossify/calendar/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/activities/SettingsActivity.kt
@@ -878,13 +878,15 @@ class SettingsActivity : SimpleActivity() {
         settingsEnableAutomaticBackupsHolder.setOnClickListener {
             val wasBackupDisabled = !config.autoBackup
             if (wasBackupDisabled) {
-                ManageAutomaticBackupsDialog(
-                    activity = this@SettingsActivity,
-                    onSuccess = {
-                        enableOrDisableAutomaticBackups(true)
-                        scheduleNextAutomaticBackup()
-                    }
-                )
+                maybeRequestExactAlarmPermission {
+                    ManageAutomaticBackupsDialog(
+                        activity = this@SettingsActivity,
+                        onSuccess = {
+                            enableOrDisableAutomaticBackups(true)
+                            scheduleNextAutomaticBackup()
+                        }
+                    )
+                }
             } else {
                 cancelScheduledAutomaticBackup()
                 enableOrDisableAutomaticBackups(false)
@@ -895,12 +897,14 @@ class SettingsActivity : SimpleActivity() {
     private fun setupManageAutomaticBackups() = binding.apply {
         settingsManageAutomaticBackupsHolder.beVisibleIf(isRPlus() && config.autoBackup)
         settingsManageAutomaticBackupsHolder.setOnClickListener {
-            ManageAutomaticBackupsDialog(
-                activity = this@SettingsActivity,
-                onSuccess = {
-                    scheduleNextAutomaticBackup()
-                }
-            )
+            maybeRequestExactAlarmPermission {
+                ManageAutomaticBackupsDialog(
+                    activity = this@SettingsActivity,
+                    onSuccess = {
+                        scheduleNextAutomaticBackup()
+                    }
+                )
+            }
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -300,6 +300,9 @@
     <string name="accessibility_previous_day">Go to previous day</string>
     <string name="accessibility_next_day">Go to next day</string>
 
+    <!-- Permissions -->
+    <string name="allow_alarms_reminders">You must allow the app to schedule alarms for reminders to work properly.</string>
+
     <!-- FAQ -->
     <string name="faq_1_title">How can I remove the holidays imported via the \"Add holidays\" button?</string>
     <string name="faq_1_text">Holidays created that way are inserted in a new event type called \"Holidays\". You can go in Settings -> Manage Event Types,


### PR DESCRIPTION
This should help in case the exact alarm permission was revoked for some reason (user error or system optimization). Without this permission, the app falls back to inexact alarms, which may be the reason for delayed reminder reports on Android 12 devices.

See https://github.com/FossifyOrg/Calendar/issues/217 and friends for more info.