### PR TITLE
fix: default to "Confirmed" when event status is missing or null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Synchronized events with unspecified status are now treated as confirmed ([#761]) 
+
 ### Fixed
 - Fixed editing only the selected occurrence of a repeating event ([#138], [#486], [#706])
 
@@ -138,6 +141,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#706]: https://github.com/FossifyOrg/Calendar/issues/706
 [#729]: https://github.com/FossifyOrg/Calendar/issues/729
 [#732]: https://github.com/FossifyOrg/Calendar/issues/732
+[#761]: http://github.com/FossifyOrg/Calendar/issues/761
 
 [Unreleased]: https://github.com/FossifyOrg/Calendar/compare/1.6.1...HEAD
 [1.6.1]: https://github.com/FossifyOrg/Calendar/compare/1.6.0...1.6.1

--- a/app/src/main/kotlin/org/fossify/calendar/helpers/CalDAVHelper.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/helpers/CalDAVHelper.kt
@@ -242,7 +242,7 @@ class CalDAVHelper(val context: Context) {
             val attendees = getCalDAVEventAttendees(id, calendar)
             val accessLevel = cursor.getIntValue(Events.ACCESS_LEVEL)
             val availability = cursor.getIntValue(Events.AVAILABILITY)
-            val status = cursor.getIntValue(Events.STATUS)
+            val status = cursor.getIntValueOrNull(Events.STATUS) ?: Events.STATUS_CONFIRMED
             val color = cursor.getIntValueOrNull(Events.EVENT_COLOR) ?: 0
 
             if (endTS == 0L) {


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why

- When fetching CalDAV events, the app will now treat `null` status as confirmed. Android defaults to tentative in this case, but that isn't desirable as per #761.

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes http://github.com/FossifyOrg/Calendar/issues/761

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
