### PR TITLE
fix app crash by saving minimalState on rotation #644

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed event duplication when editing instances of recurring events ([#138])
 - Fixed old reminders not being removed when moving events ([#486])
 - Fixed drag and drop copying events instead of moving them ([#706])
+- Fixed app crash after several rotations ([#644])
 
 ## [1.6.1] - 2025-09-01
 ### Changed
@@ -144,6 +145,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#729]: https://github.com/FossifyOrg/Calendar/issues/729
 [#732]: https://github.com/FossifyOrg/Calendar/issues/732
 [#761]: http://github.com/FossifyOrg/Calendar/issues/761
+[#644]: http://github.com/FossifyOrg/Calendar/issues/644
 
 [Unreleased]: https://github.com/FossifyOrg/Calendar/compare/1.6.1...HEAD
 [1.6.1]: https://github.com/FossifyOrg/Calendar/compare/1.6.0...1.6.1

--- a/app/src/main/kotlin/org/fossify/calendar/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/activities/MainActivity.kt
@@ -1407,4 +1407,9 @@ class MainActivity : SimpleActivity(), RefreshRecyclerViewListener {
             checkWhatsNew(this, org.fossify.calendar.BuildConfig.VERSION_CODE)
         }
     }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        val minimalState = Bundle()
+        super.onSaveInstanceState(minimalState)
+    }
 }


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- fix app crash by saving minimalState on rotation 

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - tried rotation 20-30 times without crash (more seems to be unrealistic)

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes #644 

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
