### PR TITLE
fix: clear attendees before event serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed event duplication when editing instances of recurring events ([#138])
 - Fixed old reminders not being removed when moving events ([#486])
 - Fixed drag and drop copying events instead of moving them ([#706])
+- Fixed crash when editing events with attendees ([#34])
 
 ## [1.6.1] - 2025-09-01
 ### Changed
@@ -125,6 +126,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
+[#34]: https://github.com/FossifyOrg/Calendar/issues/34
 [#138]: https://github.com/FossifyOrg/Calendar/issues/138
 [#148]: https://github.com/FossifyOrg/Calendar/issues/148
 [#196]: https://github.com/FossifyOrg/Calendar/issues/196

--- a/app/src/main/kotlin/org/fossify/calendar/activities/EventActivity.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/activities/EventActivity.kt
@@ -286,7 +286,7 @@ class EventActivity : SimpleActivity() {
         }
 
         outState.apply {
-            putSerializable(EVENT, mEvent)
+            putSerializable(EVENT, mEvent.copy(attendees = emptyList()))
             putLong(START_TS, mEventStartDateTime.seconds())
             putLong(END_TS, mEventEndDateTime.seconds())
             putString(TIME_ZONE, mEvent.timeZone)
@@ -352,6 +352,7 @@ class EventActivity : SimpleActivity() {
             val token = object : TypeToken<List<Attendee>>() {}.type
             mAttendees =
                 Gson().fromJson<ArrayList<Attendee>>(getString(ATTENDEES), token) ?: ArrayList()
+            mEvent.attendees = mAttendees
 
             mEventTypeId = getLong(EVENT_TYPE_ID)
             mEventCalendarId = getInt(EVENT_CALENDAR_ID)


### PR DESCRIPTION

<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
Skipped indirect serialization/deserialization of attendees (already managed independently using Gson). It's not completely clear why I did what I did in https://github.com/SimpleMobileTools/Simple-Calendar/pull/2215 and https://github.com/SimpleMobileTools/Simple-Calendar/pull/2216, so this is the safest fix for now.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Changing timezone in the event editor
 - Changing system theme while in the editor
 - Opening and closing the editor using the home button

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Calendar/issues/34

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [ ] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [ ] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
