### PR TITLE
fix: prevent silent discard of event/task edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed old reminders not being removed when moving events ([#486])
 - Fixed drag and drop copying events instead of moving them ([#706])
 - Fixed crash when editing events with attendees ([#34])
+- Fixed event edits being silently discarded when using navigation arrow ([#803])
 
 ## [1.6.1] - 2025-09-01
 ### Changed
@@ -146,6 +147,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#729]: https://github.com/FossifyOrg/Calendar/issues/729
 [#732]: https://github.com/FossifyOrg/Calendar/issues/732
 [#761]: http://github.com/FossifyOrg/Calendar/issues/761
+[#803]: https://github.com/FossifyOrg/Calendar/issues/803
 
 [Unreleased]: https://github.com/FossifyOrg/Calendar/compare/1.6.1...HEAD
 [1.6.1]: https://github.com/FossifyOrg/Calendar/compare/1.6.0...1.6.1

--- a/app/src/main/kotlin/org/fossify/calendar/activities/EventActivity.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/activities/EventActivity.kt
@@ -254,6 +254,10 @@ class EventActivity : SimpleActivity() {
 
     override fun onResume() {
         super.onResume()
+        setupToolbar()
+    }
+
+    private fun setupToolbar() {
         setupToolbar(binding.eventToolbar, NavigationIcon.Arrow)
         binding.eventToolbar.setNavigationOnClickListener {
             maybeShowUnsavedChangesDialog {

--- a/app/src/main/kotlin/org/fossify/calendar/activities/EventActivity.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/activities/EventActivity.kt
@@ -255,9 +255,21 @@ class EventActivity : SimpleActivity() {
     override fun onResume() {
         super.onResume()
         setupToolbar(binding.eventToolbar, NavigationIcon.Arrow)
+        binding.eventToolbar.setNavigationOnClickListener {
+            maybeShowUnsavedChangesDialog {
+                hideKeyboard()
+                finish()
+            }
+        }
     }
 
     override fun onBackPressed() {
+        maybeShowUnsavedChangesDialog {
+            super.onBackPressed()
+        }
+    }
+
+    private fun maybeShowUnsavedChangesDialog(discard: () -> Unit) {
         val now = System.currentTimeMillis()
         if (now - mLastSavePromptTS > SAVE_DISCARD_PROMPT_INTERVAL && isEventChanged()) {
             mLastSavePromptTS = now
@@ -271,11 +283,11 @@ class EventActivity : SimpleActivity() {
                 if (it) {
                     saveCurrentEvent()
                 } else {
-                    super.onBackPressed()
+                    discard()
                 }
             }
         } else {
-            super.onBackPressed()
+            discard()
         }
     }
 

--- a/app/src/main/kotlin/org/fossify/calendar/activities/TaskActivity.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/activities/TaskActivity.kt
@@ -86,6 +86,10 @@ class TaskActivity : SimpleActivity() {
 
     override fun onResume() {
         super.onResume()
+        setupToolbar()
+    }
+
+    private fun setupToolbar() {
         setupToolbar(binding.taskToolbar, NavigationIcon.Arrow)
         binding.taskToolbar.setNavigationOnClickListener {
             maybeShowUnsavedChangesDialog {

--- a/app/src/main/kotlin/org/fossify/calendar/activities/TaskActivity.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/activities/TaskActivity.kt
@@ -87,6 +87,12 @@ class TaskActivity : SimpleActivity() {
     override fun onResume() {
         super.onResume()
         setupToolbar(binding.taskToolbar, NavigationIcon.Arrow)
+        binding.taskToolbar.setNavigationOnClickListener {
+            maybeShowUnsavedChangesDialog {
+                hideKeyboard()
+                finish()
+            }
+        }
     }
 
     private fun refreshMenuItems() {
@@ -137,6 +143,12 @@ class TaskActivity : SimpleActivity() {
     }
 
     override fun onBackPressed() {
+        maybeShowUnsavedChangesDialog {
+            super.onBackPressed()
+        }
+    }
+
+    private fun maybeShowUnsavedChangesDialog(discard: () -> Unit) {
         if (System.currentTimeMillis() - mLastSavePromptTS > SAVE_DISCARD_PROMPT_INTERVAL && isTaskChanged()) {
             mLastSavePromptTS = System.currentTimeMillis()
             ConfirmationAdvancedDialog(
@@ -149,11 +161,11 @@ class TaskActivity : SimpleActivity() {
                 if (it) {
                     saveCurrentTask()
                 } else {
-                    super.onBackPressed()
+                    discard()
                 }
             }
         } else {
-            super.onBackPressed()
+            discard()
         }
     }
 


### PR DESCRIPTION

<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
Applied the same fix as https://github.com/FossifyOrg/Contacts/pull/362 in both event and task editors. Some edits are still being discarded due to https://github.com/FossifyOrg/Calendar/issues/49, which I will address in another PR soon.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Back navigation using the arrow button after editing events/tasks

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Calendar/issues/803

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
