### PR TITLE
fix: check all fields for unsaved changes on back press

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed old reminders not being removed when moving events ([#486])
 - Fixed drag and drop copying events instead of moving them ([#706])
 - Fixed crash when editing events with attendees ([#34])
-- Fixed event edits being silently discarded when using navigation arrow ([#803])
+- Fixed event edits being silently discarded on back press ([#49])
 
 ## [1.6.1] - 2025-09-01
 ### Changed
@@ -128,6 +128,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release
 
 [#34]: https://github.com/FossifyOrg/Calendar/issues/34
+[#49]: https://github.com/FossifyOrg/Calendar/issues/49
 [#138]: https://github.com/FossifyOrg/Calendar/issues/138
 [#148]: https://github.com/FossifyOrg/Calendar/issues/148
 [#196]: https://github.com/FossifyOrg/Calendar/issues/196

--- a/app/src/main/kotlin/org/fossify/calendar/activities/EventActivity.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/activities/EventActivity.kt
@@ -650,7 +650,7 @@ class EventActivity : SimpleActivity() {
                 mRepeatInterval != mEvent.repeatInterval ||
                 mRepeatRule != mEvent.repeatRule ||
                 mRepeatLimit != mEvent.repeatLimit ||
-                mAttendees != mEvent.attendees ||
+                getAllAttendees(false) != mEvent.attendees ||
                 mAvailability != mEvent.availability ||
                 mAccessLevel != mEvent.accessLevel ||
                 mStatus != mEvent.status ||

--- a/app/src/main/kotlin/org/fossify/calendar/activities/EventActivity.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/activities/EventActivity.kt
@@ -649,6 +649,11 @@ class EventActivity : SimpleActivity() {
                 reminders != mEvent.getReminders() ||
                 mRepeatInterval != mEvent.repeatInterval ||
                 mRepeatRule != mEvent.repeatRule ||
+                mRepeatLimit != mEvent.repeatLimit ||
+                mAttendees != mEvent.attendees ||
+                mAvailability != mEvent.availability ||
+                mAccessLevel != mEvent.accessLevel ||
+                mStatus != mEvent.status ||
                 mEventTypeId != mEvent.eventType ||
                 mWasCalendarChanged ||
                 mIsAllDayEvent != mEvent.getIsAllDay() ||

--- a/app/src/main/kotlin/org/fossify/calendar/activities/TaskActivity.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/activities/TaskActivity.kt
@@ -141,6 +141,7 @@ class TaskActivity : SimpleActivity() {
             reminders != originalReminders ||
             mRepeatInterval != mTask.repeatInterval ||
             mRepeatRule != mTask.repeatRule ||
+            mRepeatLimit != mTask.repeatLimit ||
             mEventTypeId != mTask.eventType ||
             mEventColor != mTask.color ||
             hasTimeChanged


### PR DESCRIPTION

<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
1. Updated the `isEventChanged()` function to check for:
	 - Repeat limit (recurrence end)
	 - Attendees
	 - Availability (free/busy)
	 - Access level (private/public/confidential)
	 - Event status (confirmed/tentative/cancelled)
2. Updated the `isTaskChanged()` function  to check for:
	 - Repeat limit (recurrence end)

The issue also mentioned the timezone field, but that seems to already work properly.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
Tested discarding:
 - [x] Repeat limit (recurrence end)
 - [x] Attendees
 - [x] Availability (free/busy)
 - [x] Access level (private/public/confidential)
 - [x] Event status (confirmed/tentative/cancelled)

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Calendar/issues/49

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
