### PR TITLE
add autocomplete

### DIFF
--- a/app/src/main/kotlin/org/fossify/calendar/activities/EventActivity.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/activities/EventActivity.kt
@@ -231,10 +231,46 @@ class EventActivity : SimpleActivity() {
         val eventId = intent.getLongExtra(EVENT_ID, 0L)
         ensureBackgroundThread {
             val locations = eventsDB.getAllLocations()
+            val eventTitleMap = eventsDB.getAllEvents()
+                .associateBy { it.title } as HashMap<String, Event>
+            binding.eventTitle.setOnItemClickListener { parent, view, position, id ->
+                val prev = eventTitleMap[parent.getItemAtPosition(position)]
+                binding.eventLocation.setText(prev!!.location)
+                binding.eventDescription.setText(prev.description)
+
+                binding.eventAllDay.isChecked = prev.getIsAllDay()
+                mEventEndDateTime = mEventStartDateTime.plus(1000L * (prev.endTS - prev.startTS))
+
+                mReminder1Minutes = prev.reminder1Minutes
+                mReminder2Minutes = prev.reminder2Minutes
+                mReminder3Minutes = prev.reminder3Minutes
+
+                mReminder1Type = prev.reminder1Type
+                mReminder2Type = prev.reminder2Type
+                mReminder3Type = prev.reminder3Type
+
+                mAccessLevel = prev.accessLevel
+                mAvailability = prev.availability
+                mStatus = prev.status
+                mEventColor = prev.color
+
+                mAttendees = prev.attendees as ArrayList<Attendee>
+
+                mCalendarId = prev.calendarId
+
+                checkRepeatTexts(mRepeatInterval)
+                checkRepeatRule()
+                updateTexts()
+                updateCalendar()
+                checkAttendees()
+                updateActionBarTitle()
+            }
 
             runOnUiThread {
-                val adapter = ArrayAdapter(this, R.layout.item_dropdown, locations)
-                binding.eventLocation.setAdapter(adapter)
+                val locationAdapter = ArrayAdapter(this, R.layout.item_dropdown, locations)
+                binding.eventLocation.setAdapter(locationAdapter)
+                val titleAdapter = ArrayAdapter(this, R.layout.item_dropdown, eventTitleMap.keys.toList())
+                binding.eventTitle.setAdapter(titleAdapter)
             }
 
             val event = eventsDB.getEventWithId(eventId)

--- a/app/src/main/res/layout/activity_event.xml
+++ b/app/src/main/res/layout/activity_event.xml
@@ -35,7 +35,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
-            <AutoCompleteTextView
+            <org.fossify.commons.views.MyAutoCompleteTextView
                 android:id="@+id/event_title"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_event.xml
+++ b/app/src/main/res/layout/activity_event.xml
@@ -35,7 +35,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
-            <org.fossify.commons.views.MyEditText
+            <AutoCompleteTextView
                 android:id="@+id/event_title"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [ ] Bug fix
- [X] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- replace the text edit with an autocomplete field
- add completion logic in `EventActivity`

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - create event with all reminders, new event type, colour, description, location, availability
 -  add new event, input two characters of old title, select event
 - all fields copied from old event

#### After preview
<img width="394" src="https://github.com/user-attachments/assets/f3d91f60-a061-4ee3-9e93-d08adeb8d810" />
<img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/90d14a07-9f63-4c8f-9c06-7c10f0bdf39e" width=394 />

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes #579

#### Checklist
- [X] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [X] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [X] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
I copied almost all fields, maybe not all should be assigned?
#393 is now trivial, I can make a follow-up PR if you want