### PR TITLE
fix: prevent `NoSuchElementException` when fetching config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed crash in event editor when CalDAV sync is disabled ([#1024])
 
 ## [1.10.1] - 2026-02-03
 ### Changed
@@ -224,6 +226,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#917]: https://github.com/FossifyOrg/Calendar/issues/917
 [#1003]: https://github.com/FossifyOrg/Calendar/issues/1003
 [#1019]: https://github.com/FossifyOrg/Calendar/issues/1019
+[#1024]: https://github.com/FossifyOrg/Calendar/issues/1024
 
 [Unreleased]: https://github.com/FossifyOrg/Calendar/compare/1.10.1...HEAD
 [1.10.1]: https://github.com/FossifyOrg/Calendar/compare/1.10.0...1.10.1

--- a/app/src/main/kotlin/org/fossify/calendar/helpers/Config.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/helpers/Config.kt
@@ -127,7 +127,7 @@ class Config(context: Context) : BaseConfig(context) {
     var lastUsedCaldavCalendarId: Int
         get() = prefs.getInt(
             LAST_USED_CALDAV_CALENDAR,
-            getSyncedCalendarIdsAsList().first()
+            getSyncedCalendarIdsAsList().firstOrNull() ?: STORED_LOCALLY_ONLY
         )
         set(calendarId) = prefs.edit().putInt(LAST_USED_CALDAV_CALENDAR, calendarId).apply()
 


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
Updated config to use `firstOrNull()` instead of `first()`. This call there before too, but the crash started only after #1023 because it changed when the call happens.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Editing and creating events with or without CalDAV sync 

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes #1024

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
