### PR TITLE
fix: remove fragments from PagerAdapters when item is destroyed.

### DIFF
--- a/app/src/main/kotlin/org/fossify/calendar/adapters/MyDayPagerAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/adapters/MyDayPagerAdapter.kt
@@ -2,6 +2,7 @@ package org.fossify.calendar.adapters
 
 import android.os.Bundle
 import android.util.SparseArray
+import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentStatePagerAdapter
@@ -24,8 +25,20 @@ class MyDayPagerAdapter(fm: FragmentManager, private val mCodes: List<String>, p
         fragment.arguments = bundle
         fragment.mListener = mListener
 
-        mFragments.put(position, fragment)
         return fragment
+    }
+
+    override fun instantiateItem(container: ViewGroup, position: Int): Any {
+        val item = super.instantiateItem(container, position)
+        if (item is DayFragment) {
+            mFragments.put(position, item)
+        }
+        return item
+    }
+
+    override fun destroyItem(container: ViewGroup, position: Int, `object`: Any) {
+        mFragments.remove(position)
+        super.destroyItem(container, position, `object`)
     }
 
     fun updateCalendars(pos: Int) {

--- a/app/src/main/kotlin/org/fossify/calendar/adapters/MyMonthDayPagerAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/adapters/MyMonthDayPagerAdapter.kt
@@ -2,6 +2,7 @@ package org.fossify.calendar.adapters
 
 import android.os.Bundle
 import android.util.SparseArray
+import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentStatePagerAdapter
@@ -23,8 +24,20 @@ class MyMonthDayPagerAdapter(fm: FragmentManager, private val mCodes: List<Strin
         fragment.arguments = bundle
         fragment.listener = mListener
 
-        mFragments.put(position, fragment)
         return fragment
+    }
+
+    override fun instantiateItem(container: ViewGroup, position: Int): Any {
+        val item = super.instantiateItem(container, position)
+        if (item is MonthDayFragment) {
+            mFragments.put(position, item)
+        }
+        return item
+    }
+
+    override fun destroyItem(container: ViewGroup, position: Int, `object`: Any) {
+        mFragments.remove(position)
+        super.destroyItem(container, position, `object`)
     }
 
     fun updateCalendars(pos: Int) {

--- a/app/src/main/kotlin/org/fossify/calendar/adapters/MyMonthPagerAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/adapters/MyMonthPagerAdapter.kt
@@ -2,6 +2,7 @@ package org.fossify.calendar.adapters
 
 import android.os.Bundle
 import android.util.SparseArray
+import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentStatePagerAdapter
@@ -23,8 +24,20 @@ class MyMonthPagerAdapter(fm: FragmentManager, private val mCodes: List<String>,
         fragment.arguments = bundle
         fragment.listener = mListener
 
-        mFragments.put(position, fragment)
         return fragment
+    }
+
+    override fun instantiateItem(container: ViewGroup, position: Int): Any {
+        val item = super.instantiateItem(container, position)
+        if (item is MonthFragment) {
+            mFragments.put(position, item)
+        }
+        return item
+    }
+
+    override fun destroyItem(container: ViewGroup, position: Int, `object`: Any) {
+        mFragments.remove(position)
+        super.destroyItem(container, position, `object`)
     }
 
     fun updateCalendars(pos: Int) {

--- a/app/src/main/kotlin/org/fossify/calendar/adapters/MyWeekPagerAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/adapters/MyWeekPagerAdapter.kt
@@ -2,6 +2,7 @@ package org.fossify.calendar.adapters
 
 import android.os.Bundle
 import android.util.SparseArray
+import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentStatePagerAdapter
@@ -24,8 +25,20 @@ class MyWeekPagerAdapter(fm: FragmentManager, private val mWeekTimestamps: List<
         fragment.arguments = bundle
         fragment.listener = mListener
 
-        mFragments.put(position, fragment)
         return fragment
+    }
+
+    override fun instantiateItem(container: ViewGroup, position: Int): Any {
+        val item = super.instantiateItem(container, position)
+        if (item is WeekFragment) {
+            mFragments.put(position, item)
+        }
+        return item
+    }
+
+    override fun destroyItem(container: ViewGroup, position: Int, `object`: Any) {
+        mFragments.remove(position)
+        super.destroyItem(container, position, `object`)
     }
 
     fun updateScrollY(pos: Int, y: Int) {

--- a/app/src/main/kotlin/org/fossify/calendar/adapters/MyYearPagerAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/adapters/MyYearPagerAdapter.kt
@@ -2,6 +2,7 @@ package org.fossify.calendar.adapters
 
 import android.os.Bundle
 import android.util.SparseArray
+import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentStatePagerAdapter
@@ -23,8 +24,20 @@ class MyYearPagerAdapter(fm: FragmentManager, val mYears: List<Int>, private val
         fragment.arguments = bundle
         fragment.listener = mListener
 
-        mFragments.put(position, fragment)
         return fragment
+    }
+
+    override fun instantiateItem(container: ViewGroup, position: Int): Any {
+        val item = super.instantiateItem(container, position)
+        if (item is YearFragment) {
+            mFragments.put(position, item)
+        }
+        return item
+    }
+
+    override fun destroyItem(container: ViewGroup, position: Int, `object`: Any) {
+        mFragments.remove(position)
+        super.destroyItem(container, position, `object`)
     }
 
     fun updateCalendars(pos: Int) {


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Fixed memory leaks in PagerAdapters

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Tested in an emulator

#### Before & after preview
<!-- For changes affecting UI, consider attaching screenshots or a video. Delete this section otherwise. -->

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
<!-- Fossify has an **issue first** policy. Please only work on **accepted** features and bug reports. -->

Related to #644 but does not fix it completely.

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
