### PR TITLE
fix: preserve current day on rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Preserve current day when changing orientation ([#1042])
 
 ## [1.10.3] - 2026-02-14
 ### Changed
@@ -237,6 +239,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1003]: https://github.com/FossifyOrg/Calendar/issues/1003
 [#1019]: https://github.com/FossifyOrg/Calendar/issues/1019
 [#1024]: https://github.com/FossifyOrg/Calendar/issues/1024
+[#1042]: https://github.com/FossifyOrg/Calendar/issues/1042
 
 [Unreleased]: https://github.com/FossifyOrg/Calendar/compare/1.10.3...HEAD
 [1.10.3]: https://github.com/FossifyOrg/Calendar/compare/1.10.2...1.10.3

--- a/app/src/main/kotlin/org/fossify/calendar/fragments/DayFragmentsHolder.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/fragments/DayFragmentsHolder.kt
@@ -34,6 +34,9 @@ class DayFragmentsHolder : MyFragmentHolder(), NavigationListener {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         currentDayCode = arguments?.getString(DAY_CODE) ?: ""
+        if (savedInstanceState != null) {
+            currentDayCode = savedInstanceState.getString(::currentDayCode.name) ?: currentDayCode
+        }
         todayDayCode = Formatter.getTodayCode()
     }
 
@@ -44,6 +47,11 @@ class DayFragmentsHolder : MyFragmentHolder(), NavigationListener {
         viewPager.id = (System.currentTimeMillis() % 100000).toInt()
         setupFragment()
         return binding.root
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        outState.putString(::currentDayCode.name, currentDayCode)
+        super.onSaveInstanceState(outState)
     }
 
     private fun setupFragment() {

--- a/app/src/main/kotlin/org/fossify/calendar/fragments/MonthDayFragmentsHolder.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/fragments/MonthDayFragmentsHolder.kt
@@ -37,6 +37,9 @@ class MonthDayFragmentsHolder : MyFragmentHolder(), NavigationListener {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         currentDayCode = arguments?.getString(DAY_CODE) ?: ""
+        if (savedInstanceState != null) {
+            currentDayCode = savedInstanceState.getString(::currentDayCode.name) ?: currentDayCode
+        }
         todayDayCode = Formatter.getTodayCode()
     }
 
@@ -47,6 +50,11 @@ class MonthDayFragmentsHolder : MyFragmentHolder(), NavigationListener {
         viewPager.id = (System.currentTimeMillis() % 100000).toInt()
         setupFragment()
         return binding.root
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        outState.putString(::currentDayCode.name, currentDayCode)
+        super.onSaveInstanceState(outState)
     }
 
     private fun setupFragment() {

--- a/app/src/main/kotlin/org/fossify/calendar/fragments/MonthFragmentsHolder.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/fragments/MonthFragmentsHolder.kt
@@ -37,6 +37,9 @@ class MonthFragmentsHolder : MyFragmentHolder(), NavigationListener {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         currentDayCode = arguments?.getString(DAY_CODE) ?: ""
+        if (savedInstanceState != null) {
+            currentDayCode = savedInstanceState.getString(::currentDayCode.name) ?: currentDayCode
+        }
         todayDayCode = Formatter.getTodayCode()
     }
 
@@ -47,6 +50,11 @@ class MonthFragmentsHolder : MyFragmentHolder(), NavigationListener {
         viewPager.id = (System.currentTimeMillis() % 100000).toInt()
         setupFragment()
         return binding.root
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        outState.putString(::currentDayCode.name, currentDayCode)
+        super.onSaveInstanceState(outState)
     }
 
     private fun setupFragment() {

--- a/app/src/main/kotlin/org/fossify/calendar/fragments/WeekFragmentsHolder.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/fragments/WeekFragmentsHolder.kt
@@ -44,6 +44,9 @@ class WeekFragmentsHolder : MyFragmentHolder(), WeekFragmentListener {
         super.onCreate(savedInstanceState)
         val dateTimeString = arguments?.getString(WEEK_START_DATE_TIME) ?: return
         currentWeekTS = (DateTime.parse(dateTimeString) ?: DateTime()).seconds()
+        if (savedInstanceState != null) {
+            currentWeekTS = savedInstanceState.getLong(::currentWeekTS.name)
+        }
         updateThisWeekTS()
     }
 
@@ -70,6 +73,11 @@ class WeekFragmentsHolder : MyFragmentHolder(), WeekFragmentListener {
             binding.weekViewSeekbar.beVisibleIf(allow)
         }
         setupSeekbar()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        outState.putLong(::currentWeekTS.name, currentWeekTS)
+        super.onSaveInstanceState(outState)
     }
 
     private fun setupFragment() {

--- a/app/src/main/kotlin/org/fossify/calendar/fragments/YearFragmentsHolder.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/fragments/YearFragmentsHolder.kt
@@ -37,6 +37,9 @@ class YearFragmentsHolder : MyFragmentHolder(), NavigationListener {
         super.onCreate(savedInstanceState)
         val dateTimeString = arguments?.getString(YEAR_TO_OPEN)
         currentYear = (if (dateTimeString != null) DateTime.parse(dateTimeString) else DateTime()).toString(Formatter.YEAR_PATTERN).toInt()
+        if (savedInstanceState != null) {
+            currentYear = savedInstanceState.getInt(::currentYear.name)
+        }
         todayYear = DateTime().toString(Formatter.YEAR_PATTERN).toInt()
     }
 
@@ -47,6 +50,11 @@ class YearFragmentsHolder : MyFragmentHolder(), NavigationListener {
         viewPager.id = (System.currentTimeMillis() % 100000).toInt()
         setupFragment()
         return binding.root
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        outState.putInt(::currentYear.name, currentYear)
+        super.onSaveInstanceState(outState)
     }
 
     private fun setupFragment() {


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
This change preserves the current selected day when you rotate the device.

#### Tests performed
I did some tests on an emulator

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
<!-- Fossify has an **issue first** policy. Please only work on **accepted** features and bug reports. -->
- Closes #1042

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
