### PR TITLE
fix: improve icalendar export

### DIFF
--- a/app/src/main/kotlin/org/fossify/calendar/helpers/IcsExporter.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/helpers/IcsExporter.kt
@@ -71,30 +71,30 @@ class IcsExporter(private val context: Context) {
         }
     }
 
-    private fun fillReminders(event: Event, outputStream: OutputStream, reminderLabel: String) {
+    private fun fillReminders(event: Event, out: OutputStream, reminderLabel: String) {
         event.getReminders().forEach { reminder ->
-            outputStream.writeContentLine(BEGIN_ALARM)
-            outputStream.writeTextProperty(DESCRIPTION, reminderLabel)
+            out.writeContentLine(BEGIN_ALARM)
+            out.writeTextProperty(DESCRIPTION, reminderLabel)
             if (reminder.type == REMINDER_NOTIFICATION) {
-                outputStream.writeContentLine("$ACTION$DISPLAY")
+                out.writeContentLine("$ACTION$DISPLAY")
             } else {
-                outputStream.writeContentLine("$ACTION$EMAIL")
+                out.writeContentLine("$ACTION$EMAIL")
                 val attendee =
                     calendars.firstOrNull { it.id == event.getCalDAVCalendarId() }?.accountName
                 if (attendee != null) {
-                    outputStream.writeContentLine("$ATTENDEE$MAILTO$attendee")
+                    out.writeContentLine("$ATTENDEE$MAILTO$attendee")
                 }
             }
 
             val sign = if (reminder.minutes < -1) "" else "-"
-            outputStream.writeContentLine("$TRIGGER:$sign${Parser().getDurationCode(abs(reminder.minutes.toLong()))}")
-            outputStream.writeContentLine(END_ALARM)
+            out.writeContentLine("$TRIGGER:$sign${Parser().getDurationCode(abs(reminder.minutes.toLong()))}")
+            out.writeContentLine(END_ALARM)
         }
     }
 
-    private fun fillIgnoredOccurrences(event: Event, outputStream: OutputStream) {
+    private fun fillIgnoredOccurrences(event: Event, out: OutputStream) {
         event.repetitionExceptions.forEach {
-            outputStream.writeContentLine("$EXDATE:$it")
+            out.writeContentLine("$EXDATE:$it")
         }
     }
 

--- a/app/src/main/kotlin/org/fossify/calendar/helpers/IcsExporter.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/helpers/IcsExporter.kt
@@ -89,7 +89,7 @@ class IcsExporter(private val context: Context) {
             val reminder = it
             out.apply {
                 writeContentLine(BEGIN_ALARM)
-                writeContentLine("$DESCRIPTION_EXPORT$reminderLabel")
+                writeTextProperty(DESCRIPTION, reminderLabel)
                 if (reminder.type == REMINDER_NOTIFICATION) {
                     writeContentLine("$ACTION$DISPLAY")
                 } else {
@@ -157,10 +157,10 @@ class IcsExporter(private val context: Context) {
                 }
                 writeContentLine("$FOSSIFY_COLOR${event.color}")
             }
-            writeContentLine("$CATEGORIES${context.calendarsDB.getCalendarWithId(event.calendarId)?.title}")
+            writeTextProperty("CATEGORIES", context.calendarsDB.getCalendarWithId(event.calendarId)?.title ?: "")
             writeContentLine("$LAST_MODIFIED:${Formatter.getExportedTime(event.lastUpdated)}")
             writeContentLine("$TRANSP${if (event.availability == Events.AVAILABILITY_FREE) TRANSPARENT else OPAQUE}")
-            event.location.let { if (it.isNotEmpty()) writeContentLine("$LOCATION:$it") }
+            event.location.let { if (it.isNotEmpty()) writeTextProperty(LOCATION, it) }
 
             if (event.getIsAllDay()) {
                 val tz = try {
@@ -211,9 +211,9 @@ class IcsExporter(private val context: Context) {
                 }
                 writeContentLine("$FOSSIFY_COLOR${task.color}")
             }
-            writeContentLine("$CATEGORIES${context.calendarsDB.getCalendarWithId(task.calendarId)?.title}")
+            writeTextProperty("CATEGORIES", context.calendarsDB.getCalendarWithId(task.calendarId)?.title ?: "")
             writeContentLine("$LAST_MODIFIED:${Formatter.getExportedTime(task.lastUpdated)}")
-            task.location.let { if (it.isNotEmpty()) writeContentLine("$LOCATION:$it") }
+            task.location.let { if (it.isNotEmpty()) writeTextProperty(LOCATION, it) }
 
             if (task.getIsAllDay()) {
                 writeContentLine("$DTSTART;$VALUE=$DATE:${Formatter.getDayCodeFromTS(task.startTS)}")

--- a/app/src/main/kotlin/org/fossify/calendar/helpers/IcsExporter.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/helpers/IcsExporter.kt
@@ -9,7 +9,7 @@ import org.fossify.calendar.extensions.eventsHelper
 import org.fossify.calendar.helpers.IcsExporter.ExportResult.EXPORT_FAIL
 import org.fossify.calendar.helpers.IcsExporter.ExportResult.EXPORT_OK
 import org.fossify.calendar.helpers.IcsExporter.ExportResult.EXPORT_PARTIAL
-import org.fossify.calendar.icalendar.ContentLineFolder
+import org.fossify.calendar.icalendar.ContentLineWriter
 import org.fossify.calendar.models.CalDAVCalendar
 import org.fossify.calendar.models.Event
 import org.fossify.commons.extensions.toast
@@ -17,13 +17,8 @@ import org.fossify.commons.helpers.ensureBackgroundThread
 import org.joda.time.DateTimeZone
 import java.io.BufferedOutputStream
 import java.io.OutputStream
-import java.nio.charset.Charset
 
 class IcsExporter(private val context: Context) {
-    companion object {
-        val DEFAULT_CHARSET: Charset = Charsets.UTF_8
-    }
-
     enum class ExportResult {
         EXPORT_FAIL, EXPORT_OK, EXPORT_PARTIAL
     }
@@ -198,14 +193,9 @@ class IcsExporter(private val context: Context) {
         }
     }
 
-    private val contentLineFolder = ContentLineFolder()
+    private val contentLineWriter = ContentLineWriter()
 
-    private fun OutputStream.writeContentLine(line: String) {
-        for (segment in contentLineFolder.fold(line)) {
-            this.write(segment.toByteArray(DEFAULT_CHARSET))
-            this.write("\r\n".toByteArray(DEFAULT_CHARSET))
-        }
-    }
+    private fun OutputStream.writeContentLine(line: String) = contentLineWriter.write(this, line)
 
     private fun OutputStream.writeTextProperty(name: String, value: String) {
         val normalizedValue = value

--- a/app/src/main/kotlin/org/fossify/calendar/icalendar/ContentLineFolder.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/icalendar/ContentLineFolder.kt
@@ -1,0 +1,36 @@
+package org.fossify.calendar.icalendar
+
+internal class ContentLineFolder {
+    companion object {
+        private const val MAX_LINE_LENGTH = 75
+    }
+
+    fun fold(line: String): Sequence<String> = sequence {
+        var index = 0
+        var isFirstLine = true
+
+        while (index < line.length) {
+            var end = index + MAX_LINE_LENGTH
+            // Take the prepended space into account.
+            if (!isFirstLine) end--
+            if (end > line.length) {
+                end = line.length
+            } else {
+                // Avoid splitting surrogate pairs
+                if (Character.isHighSurrogate(line[end - 1])) {
+                    end--
+                }
+            }
+
+            val substring = line.substring(index, end)
+            if (isFirstLine) {
+                yield(substring)
+            } else {
+                yield(" $substring")
+            }
+
+            isFirstLine = false
+            index = end
+        }
+    }
+}

--- a/app/src/main/kotlin/org/fossify/calendar/icalendar/ContentLineFolder.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/icalendar/ContentLineFolder.kt
@@ -1,8 +1,8 @@
 package org.fossify.calendar.icalendar
 
-internal class ContentLineFolder {
+internal class ContentLineFolder(private val maxLength: Int = DEFAULT_MAX_LENGTH) {
     companion object {
-        private const val MAX_LINE_LENGTH = 75
+        private const val DEFAULT_MAX_LENGTH = 75
     }
 
     fun fold(line: String): Sequence<String> = sequence {
@@ -10,7 +10,7 @@ internal class ContentLineFolder {
         var isFirstLine = true
 
         while (index < line.length) {
-            var end = index + MAX_LINE_LENGTH
+            var end = index + maxLength
             // Take the prepended space into account.
             if (!isFirstLine) end--
             if (end > line.length) {

--- a/app/src/main/kotlin/org/fossify/calendar/icalendar/ContentLineWriter.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/icalendar/ContentLineWriter.kt
@@ -1,0 +1,21 @@
+package org.fossify.calendar.icalendar
+
+import java.io.OutputStream
+import java.nio.charset.Charset
+
+internal class ContentLineWriter(
+    private val charset: Charset = DEFAULT_CHARSET,
+    private val folder: ContentLineFolder = ContentLineFolder()
+) {
+    companion object {
+        val DEFAULT_CHARSET: Charset = Charsets.UTF_8
+        private const val CRLF = "\r\n"
+    }
+
+    fun write(outputStream: OutputStream, line: String) {
+        for (segment in folder.fold(line)) {
+            outputStream.write(segment.toByteArray(charset))
+            outputStream.write(CRLF.toByteArray(charset))
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
The implementation of the IcsExporter class has been changed to do proper normalizing, escaping and line folding as specified in RFC 5545. I created functions to write content lines using the proper line endings and to do line folding for all content lines, not just descriptions.
Also there is a method added to write TEXT properties, which have additional escaping rules for newlines and characters like ',' and ';'.

#### Tests performed
I did some tests with long lines, line breaks and characters like , and ; which should be escaped in the output.

For example a to-do with a long title and a long description:
**Before**
```icalendar
BEGIN:VCALENDAR
PRODID:-//Fossify//NONSGML Event Calendar//EN
VERSION:2.0
BEGIN:VTODO
SUMMARY:This task has a very long title and doesn't fit on a single content line. It must be folded properly
UID:6272ad534681402ca13deee8c9d2a5811771114583194
X-FOSSIFY-CATEGORY-COLOR:-8417344
CATEGORIES:Lokale agenda
LAST-MODIFIED:20260215T234152Z
DTSTART;VALUE=DATE:20260215
DTSTAMP:20260218T181614Z
DESCRIPTION:The description is also way too long for a single content line and must als
 o be folded properly\n\nNewlines should also be properly handled.\n\nAs wel
 l as ";" and ","
BEGIN:VALARM
DESCRIPTION:Herinnering
ACTION:DISPLAY
TRIGGER:-P0DT0H10M0S
END:VALARM
END:VTODO
END:VCALENDAR
```
<img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/9509b112-51ce-4780-9a58-f85213d0b23e" width=600 />


**After**
```icalendar
BEGIN:VCALENDAR
PRODID:-//Fossify//NONSGML Event Calendar//EN
VERSION:2.0
BEGIN:VTODO
SUMMARY:This task has a very long title and doesn't fit on a single content
  line. It must be folded properly
UID:6272ad534681402ca13deee8c9d2a5811771114583194
X-FOSSIFY-CATEGORY-COLOR:-8417344
CATEGORIES:Lokale agenda
LAST-MODIFIED:20260215T234152Z
DTSTART;VALUE=DATE:20260215
DTSTAMP:20260218T095821Z
DESCRIPTION:The description is also way too long for a single content line 
 and must also be folded properly\n\nNewlines should also be properly handl
 ed.\n\nAs well as "\;" and "\,"
BEGIN:VALARM
DESCRIPTION:Herinnering
ACTION:DISPLAY
TRIGGER:-P0DT0H10M0S
END:VALARM
END:VTODO
END:VCALENDAR
```
<img width="290" height="97" alt="afbeelding" src="https://github.com/user-attachments/assets/b39ecfc5-5ca8-47b8-bd1a-2d724625733a" />

I used https://icalendar.org/validator.html to validate the results.

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
<!-- Fossify has an **issue first** policy. Please only work on **accepted** features and bug reports. -->

- Closes #899

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
