### PR TITLE
fix: Monthly widget doesn't show multiple-day events properly #15

### DIFF
--- a/app/src/main/kotlin/org/fossify/calendar/helpers/MyWidgetMonthlyProvider.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/helpers/MyWidgetMonthlyProvider.kt
@@ -99,7 +99,6 @@ class MyWidgetMonthlyProvider : AppWidgetProvider() {
         val dimCompletedTasks = context.config.dimCompletedTasks
         val smallerFontSize = context.getWidgetFontSize() - 3f
         val res = context.resources
-        val len = days.size
         val packageName = context.packageName
         views.apply {
             setTextColor(R.id.week_num, textColor)
@@ -117,15 +116,52 @@ class MyWidgetMonthlyProvider : AppWidgetProvider() {
             }
         }
 
-        for (i in 0 until len) {
-            val day = days[i]
 
+        val eventDayIndices = mutableMapOf<Pair<Long, Long>, MutableList<Int>>()
+        val eventByKey = mutableMapOf<Pair<Long, Long>, Event>()
+        for (i in days.indices) {
+            for (event in days[i].dayEvents) {
+                val key = Pair(event.id ?: 0L, event.startTS)
+                eventDayIndices.getOrPut(key) { mutableListOf() }.add(i)
+                if (key !in eventByKey) eventByKey[key] = event
+            }
+        }
+
+        val sortedKeys = eventDayIndices.keys.sortedWith(
+            compareBy(
+                { -(eventDayIndices[it]!!.size) },
+                { (eventByKey[it]!!.flags and FLAG_ALL_DAY) == 0 },
+                { eventByKey[it]!!.startTS },
+                { eventByKey[it]!!.endTS },
+                { eventDayIndices[it]!!.firstOrNull() ?: 0 },
+                { eventByKey[it]!!.title }
+            )
+        )
+
+        val daySlotIndex = IntArray(days.size) { 0 }
+        val daySlotLists = Array(days.size) { mutableListOf<Event?>() }
+        for (key in sortedKeys) {
+            val dayIndices = eventDayIndices[key]!!
+            val event = eventByKey[key]!!
+            val slot = dayIndices.maxOf { daySlotIndex[it] }
+            for (dayIdx in dayIndices) {
+                while (daySlotIndex[dayIdx] < slot) {
+                    daySlotLists[dayIdx].add(null) // invisible spacer
+                    daySlotIndex[dayIdx]++
+                }
+                daySlotLists[dayIdx].add(event)
+                daySlotIndex[dayIdx]++
+            }
+        }
+
+        val titleShownForKey = mutableSetOf<Pair<Long, Long>>()
+        for (i in days.indices) {
+            val day = days[i]
             val dayTextColor = if (context.config.highlightWeekends && day.isWeekend) {
                 context.config.highlightWeekendsColor
             } else {
                 textColor
             }
-
             val weakTextColor = dayTextColor.adjustAlpha(MEDIUM_ALPHA)
             val currTextColor = if (day.isThisMonth) dayTextColor else weakTextColor
             val id = res.getIdentifier("day_$i", "id", packageName)
@@ -133,33 +169,54 @@ class MyWidgetMonthlyProvider : AppWidgetProvider() {
             addDayNumber(context, views, day, currTextColor, id)
             setupDayOpenIntent(context, views, id, day.code)
 
-            day.dayEvents = day.dayEvents.asSequence().sortedWith(compareBy({ it.flags and FLAG_ALL_DAY == 0 }, { it.startTS }, { it.title }))
-                .toMutableList() as ArrayList<Event>
-
-            day.dayEvents.forEach {
-                val backgroundColor = it.color
-                var eventTextColor = backgroundColor.getContrastColor()
-                val shouldDim = (it.isTask() && it.isTaskCompleted() && dimCompletedTasks)
-                    || (dimPastEvents && it.isPastEvent && !it.isTask())
-                if (shouldDim) {
-                    eventTextColor = eventTextColor.adjustAlpha(MEDIUM_ALPHA)
-                }
-
-                val newRemoteView = RemoteViews(packageName, R.layout.day_monthly_event_view_widget).apply {
-                    setText(R.id.day_monthly_event_id, it.title.replace(" ", "\u00A0"))
-                    setTextColor(R.id.day_monthly_event_id, eventTextColor)
-                    setTextSize(R.id.day_monthly_event_id, smallerFontSize - 3f)
-                    setVisibleIf(R.id.day_monthly_task_image, it.isTask())
-                    applyColorFilter(R.id.day_monthly_task_image, eventTextColor)
-                    setInt(R.id.day_monthly_event_background, "setColorFilter", it.color)
-
-                    if (it.shouldStrikeThrough()) {
-                        setInt(R.id.day_monthly_event_id, "setPaintFlags", Paint.ANTI_ALIAS_FLAG or Paint.STRIKE_THRU_TEXT_FLAG)
-                    } else {
+            for (slotEvent in daySlotLists[i]) {
+                if (slotEvent == null) {
+                    val spacer = RemoteViews(packageName, R.layout.day_monthly_event_view_widget).apply {
+                        setText(R.id.day_monthly_event_id, " ")
+                        setViewVisibility(R.id.day_monthly_event_background, View.INVISIBLE)
+                        setViewVisibility(R.id.day_monthly_task_image, View.GONE)
                         setInt(R.id.day_monthly_event_id, "setPaintFlags", Paint.ANTI_ALIAS_FLAG)
                     }
+                    views.addView(id, spacer)
+                } else {
+                    val key = Pair(slotEvent.id ?: 0L, slotEvent.startTS)
+                    val showTitle = titleShownForKey.add(key) || i % 7 == 0
+                    var eventTextColor = slotEvent.color.getContrastColor()
+                    val shouldDim = (slotEvent.isTask() && slotEvent.isTaskCompleted() && dimCompletedTasks)
+                        || (dimPastEvents && slotEvent.isPastEvent && !slotEvent.isTask())
+                    if (shouldDim) {
+                        eventTextColor = eventTextColor.adjustAlpha(MEDIUM_ALPHA)
+                    }
+                    val dayIndices = eventDayIndices[key]!!
+                    val prevInRun = i > 0 && i % 7 != 0 && dayIndices.contains(i - 1)
+                    val nextInRun = i < days.size - 1 && (i + 1) % 7 != 0 && dayIndices.contains(i + 1)
+                    val eventLayout = when {
+                        prevInRun && nextInRun -> R.layout.day_monthly_event_view_widget_event_middle
+                        prevInRun             -> R.layout.day_monthly_event_view_widget_event_end
+                        nextInRun             -> R.layout.day_monthly_event_view_widget_event_start
+                        else                  -> R.layout.day_monthly_event_view_widget
+                    }
+                    val newRemoteView = RemoteViews(packageName, eventLayout).apply {
+                        setTextColor(R.id.day_monthly_event_id, eventTextColor)
+                        setTextSize(R.id.day_monthly_event_id, smallerFontSize - 3f)
+                        setInt(R.id.day_monthly_event_background, "setColorFilter", slotEvent.color)
+                        if (showTitle) {
+                            setText(R.id.day_monthly_event_id, slotEvent.title.replace(" ", "\u00A0"))
+                            setVisibleIf(R.id.day_monthly_task_image, slotEvent.isTask())
+                            applyColorFilter(R.id.day_monthly_task_image, eventTextColor)
+                            if (slotEvent.shouldStrikeThrough()) {
+                                setInt(R.id.day_monthly_event_id, "setPaintFlags", Paint.ANTI_ALIAS_FLAG or Paint.STRIKE_THRU_TEXT_FLAG)
+                            } else {
+                                setInt(R.id.day_monthly_event_id, "setPaintFlags", Paint.ANTI_ALIAS_FLAG)
+                            }
+                        } else {
+                            setText(R.id.day_monthly_event_id, "")
+                            setVisibleIf(R.id.day_monthly_task_image, false)
+                            setInt(R.id.day_monthly_event_id, "setPaintFlags", Paint.ANTI_ALIAS_FLAG)
+                        }
+                    }
+                    views.addView(id, newRemoteView)
                 }
-                views.addView(id, newRemoteView)
             }
         }
     }

--- a/app/src/main/res/drawable/day_monthly_event_background_widget_end.xml
+++ b/app/src/main/res/drawable/day_monthly_event_background_widget_end.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners
+        android:topLeftRadius="0dp"
+        android:bottomLeftRadius="0dp"
+        android:topRightRadius="2dp"
+        android:bottomRightRadius="2dp" />
+    <solid android:color="@android:color/white" />
+</shape>

--- a/app/src/main/res/drawable/day_monthly_event_background_widget_middle.xml
+++ b/app/src/main/res/drawable/day_monthly_event_background_widget_middle.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@android:color/white" />
+</shape>

--- a/app/src/main/res/drawable/day_monthly_event_background_widget_start.xml
+++ b/app/src/main/res/drawable/day_monthly_event_background_widget_start.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners
+        android:topLeftRadius="2dp"
+        android:bottomLeftRadius="2dp"
+        android:topRightRadius="0dp"
+        android:bottomRightRadius="0dp" />
+    <solid android:color="@android:color/white" />
+</shape>

--- a/app/src/main/res/layout/day_monthly_event_view_widget_event_end.xml
+++ b/app/src/main/res/layout/day_monthly_event_view_widget_event_end.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/day_monthly_event_holder"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <ImageView
+        android:id="@+id/day_monthly_event_background"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_alignBottom="@+id/day_monthly_event_id"
+        android:layout_marginTop="@dimen/one_dp"
+        android:layout_marginBottom="@dimen/one_dp"
+        android:layout_marginStart="0dp"
+        android:layout_marginEnd="@dimen/one_dp"
+        android:contentDescription="@null"
+        android:src="@drawable/day_monthly_event_background_widget_end" />
+
+    <ImageView
+        android:id="@+id/day_monthly_task_image"
+        android:layout_width="@dimen/activity_margin"
+        android:layout_height="@dimen/activity_margin"
+        android:layout_alignTop="@+id/day_monthly_event_id"
+        android:layout_alignBottom="@+id/day_monthly_event_id"
+        android:adjustViewBounds="true"
+        android:contentDescription="@string/task"
+        android:paddingStart="@dimen/one_dp"
+        android:paddingTop="@dimen/one_dp"
+        android:paddingBottom="@dimen/one_dp"
+        android:scaleType="fitCenter"
+        android:src="@drawable/ic_task_vector" />
+
+    <TextView
+        android:id="@+id/day_monthly_event_id"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_toEndOf="@+id/day_monthly_task_image"
+        android:ellipsize="none"
+        android:gravity="start"
+        android:hyphenationFrequency="none"
+        android:maxLines="1"
+        android:paddingStart="@dimen/tiny_margin"
+        android:paddingEnd="@dimen/tiny_margin"
+        android:textSize="@dimen/day_monthly_text_size"
+        tools:targetApi="m"
+        tools:text="My event" />
+
+</RelativeLayout>

--- a/app/src/main/res/layout/day_monthly_event_view_widget_event_middle.xml
+++ b/app/src/main/res/layout/day_monthly_event_view_widget_event_middle.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/day_monthly_event_holder"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <ImageView
+        android:id="@+id/day_monthly_event_background"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_alignBottom="@+id/day_monthly_event_id"
+        android:layout_marginTop="@dimen/one_dp"
+        android:layout_marginBottom="@dimen/one_dp"
+        android:layout_marginStart="0dp"
+        android:layout_marginEnd="0dp"
+        android:contentDescription="@null"
+        android:src="@drawable/day_monthly_event_background_widget_middle" />
+
+    <ImageView
+        android:id="@+id/day_monthly_task_image"
+        android:layout_width="@dimen/activity_margin"
+        android:layout_height="@dimen/activity_margin"
+        android:layout_alignTop="@+id/day_monthly_event_id"
+        android:layout_alignBottom="@+id/day_monthly_event_id"
+        android:adjustViewBounds="true"
+        android:contentDescription="@string/task"
+        android:paddingStart="@dimen/one_dp"
+        android:paddingTop="@dimen/one_dp"
+        android:paddingBottom="@dimen/one_dp"
+        android:scaleType="fitCenter"
+        android:src="@drawable/ic_task_vector" />
+
+    <TextView
+        android:id="@+id/day_monthly_event_id"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_toEndOf="@+id/day_monthly_task_image"
+        android:ellipsize="none"
+        android:gravity="start"
+        android:hyphenationFrequency="none"
+        android:maxLines="1"
+        android:paddingStart="@dimen/tiny_margin"
+        android:paddingEnd="@dimen/tiny_margin"
+        android:textSize="@dimen/day_monthly_text_size"
+        tools:targetApi="m"
+        tools:text="My event" />
+
+</RelativeLayout>

--- a/app/src/main/res/layout/day_monthly_event_view_widget_event_start.xml
+++ b/app/src/main/res/layout/day_monthly_event_view_widget_event_start.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/day_monthly_event_holder"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <ImageView
+        android:id="@+id/day_monthly_event_background"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_alignBottom="@+id/day_monthly_event_id"
+        android:layout_marginTop="@dimen/one_dp"
+        android:layout_marginBottom="@dimen/one_dp"
+        android:layout_marginStart="@dimen/one_dp"
+        android:layout_marginEnd="0dp"
+        android:contentDescription="@null"
+        android:src="@drawable/day_monthly_event_background_widget_start" />
+
+    <ImageView
+        android:id="@+id/day_monthly_task_image"
+        android:layout_width="@dimen/activity_margin"
+        android:layout_height="@dimen/activity_margin"
+        android:layout_alignTop="@+id/day_monthly_event_id"
+        android:layout_alignBottom="@+id/day_monthly_event_id"
+        android:adjustViewBounds="true"
+        android:contentDescription="@string/task"
+        android:paddingStart="@dimen/one_dp"
+        android:paddingTop="@dimen/one_dp"
+        android:paddingBottom="@dimen/one_dp"
+        android:scaleType="fitCenter"
+        android:src="@drawable/ic_task_vector" />
+
+    <TextView
+        android:id="@+id/day_monthly_event_id"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_toEndOf="@+id/day_monthly_task_image"
+        android:ellipsize="none"
+        android:gravity="start"
+        android:hyphenationFrequency="none"
+        android:maxLines="1"
+        android:paddingStart="@dimen/tiny_margin"
+        android:paddingEnd="@dimen/tiny_margin"
+        android:textSize="@dimen/day_monthly_text_size"
+        tools:targetApi="m"
+        tools:text="My event" />
+
+</RelativeLayout>


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
Fixes #15 by adding adding segmented start / middle / end backgrounds for multi-day events in the monthly widget, so that these events render as a continuous bar across day like in the in-app monthly view.

#### Tests performed
 - tested in dark and light mode on several androidStudio virtual devices in normal and biggest fontSize
 - added multiple overlapping multi-day events and single-day events that also took sometimes multiple weeks 

#### Before & after preview
Before:
<img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/b52b19c4-d417-4364-8473-f8ca4a473e54" width=178 />
After:
<img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/40010a2d-1c90-48f0-9b41-f156ffdd00dc" width=178 />


#### Closes the following issue(s)
- Closes #15 

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.
