### PR TITLE
fix: countdown to event start instead of the reminder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Countdown to event start instead of to the reminder ([#1073]) 
+
 ## [1.10.3] - 2026-02-14
 ### Changed
 - Updated translations
@@ -237,6 +240,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1003]: https://github.com/FossifyOrg/Calendar/issues/1003
 [#1019]: https://github.com/FossifyOrg/Calendar/issues/1019
 [#1024]: https://github.com/FossifyOrg/Calendar/issues/1024
+[#1073]: https://github.com/FossifyOrg/Calendar/issues/1073
 
 [Unreleased]: https://github.com/FossifyOrg/Calendar/compare/1.10.3...HEAD
 [1.10.3]: https://github.com/FossifyOrg/Calendar/compare/1.10.2...1.10.3

--- a/app/src/main/kotlin/org/fossify/calendar/extensions/Context.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/extensions/Context.kt
@@ -233,26 +233,25 @@ fun Context.scheduleNextEventReminder(event: Event, showToasts: Boolean) {
 }
 
 fun Context.scheduleEventIn(notifyAtMillis: Long, event: Event, showToasts: Boolean) {
-    val now = System.currentTimeMillis()
-    if (notifyAtMillis < now) {
+    val now = System.currentTimeMillis() / 1000
+    if (event.getEventStartTS() < now) {
         if (showToasts) {
             toast(org.fossify.commons.R.string.saving)
         }
         return
     }
 
-    val newNotifyAtMillis = notifyAtMillis + 1000
     if (showToasts) {
-        val secondsTillNotification = (newNotifyAtMillis - now) / 1000
+        val secondsTillEvent = event.getEventStartTS() - now
         val msg = String.format(
             getString(org.fossify.commons.R.string.time_remaining),
-            formatSecondsToTimeString(secondsTillNotification.toInt())
+            formatSecondsToTimeString(secondsTillEvent.toInt())
         )
         toast(msg)
     }
 
     val pendingIntent = getNotificationIntent(event)
-    setExactAlarm(newNotifyAtMillis, pendingIntent)
+    setExactAlarm(notifyAtMillis + 1000, pendingIntent)
 }
 
 // hide the actual notification from the top bar


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
Changed the time in the countdown when saving an event with a reminder. Instead of showing the time until the reminder, show the time to the start of the event.

#### Tests performed
Tested on an emulator with a couple of test events.

#### After preview
<img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/8899f122-301a-4e33-83e3-b4ea7fe5f76f" width=190 />

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
<!-- Fossify has an **issue first** policy. Please only work on **accepted** features and bug reports. -->

- Closes #1073

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
