### PR TITLE
fix: removed padding on monthly widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Removed padding around monthly calendar widget ([#63])
 
 ## [1.10.3] - 2026-02-14
 ### Changed

--- a/app/src/main/res/layout/fragment_month_widget.xml
+++ b/app/src/main/res/layout/fragment_month_widget.xml
@@ -3,8 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/calendar_wrapper"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:padding="@dimen/medium_margin">
+    android:layout_height="match_parent">
 
     <ImageView
         android:id="@+id/widget_month_background"


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [X] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- Removed padding around the monthly calendar widget. According to #63, the monthly calendar was too small compared to the other widgets.

#### Tests performed
- Tested on emulators with android 16 and android 9, both with multiple font sizes

#### Before & after preview
Before:
<img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/aa469225-24ec-4975-828a-8b1b72fe483c" width=243 />
After:
<img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/9de47781-b925-46af-b1e9-4c2c862a9782" width=243 />

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
<!-- Fossify has an **issue first** policy. Please only work on **accepted** features and bug reports. -->

- Closes #63

#### Checklist
- [X] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [X] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [X] I understand every change in this pull request.
