### PR TITLE
feat: pick (absolute) date/time for reminders

### DIFF
--- a/app/src/main/kotlin/org/fossify/calendar/activities/EventActivity.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/activities/EventActivity.kt
@@ -844,22 +844,37 @@ class EventActivity : SimpleActivity() {
     }
 
     private fun showReminder1Dialog() {
-        showPickSecondsDialogHelper(mReminder1Minutes, showDuringDayOption = mIsAllDayEvent) {
-            mReminder1Minutes = if (it == -1 || it == 0) it else it / 60
+        showPickSecondsDialogHelper(
+            curMinutes = mReminder1Minutes,
+            showDuringDayOption = mIsAllDayEvent,
+            showAbsoluteDateTimeOption = true,
+            eventStartTS = mEvent.startTS
+        ) { seconds ->
+            mReminder1Minutes = if (seconds == -1 || seconds == 0) seconds else seconds / 60
             checkReminderTexts()
         }
     }
 
     private fun showReminder2Dialog() {
-        showPickSecondsDialogHelper(mReminder2Minutes, showDuringDayOption = mIsAllDayEvent) {
-            mReminder2Minutes = if (it == -1 || it == 0) it else it / 60
+        showPickSecondsDialogHelper(
+            curMinutes = mReminder2Minutes,
+            showDuringDayOption = mIsAllDayEvent,
+            showAbsoluteDateTimeOption = true,
+            eventStartTS = mEvent.startTS
+        ) { seconds ->
+            mReminder2Minutes = if (seconds == -1 || seconds == 0) seconds else seconds / 60
             checkReminderTexts()
         }
     }
 
     private fun showReminder3Dialog() {
-        showPickSecondsDialogHelper(mReminder3Minutes, showDuringDayOption = mIsAllDayEvent) {
-            mReminder3Minutes = if (it == -1 || it == 0) it else it / 60
+        showPickSecondsDialogHelper(
+            curMinutes = mReminder3Minutes,
+            showDuringDayOption = mIsAllDayEvent,
+            showAbsoluteDateTimeOption = true,
+            eventStartTS = mEvent.startTS
+        ) { seconds ->
+            mReminder3Minutes = if (seconds == -1 || seconds == 0) seconds else seconds / 60
             checkReminderTexts()
         }
     }

--- a/app/src/main/kotlin/org/fossify/calendar/activities/TaskActivity.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/activities/TaskActivity.kt
@@ -885,22 +885,37 @@ class TaskActivity : SimpleActivity() {
     }
 
     private fun showReminder1Dialog() {
-        showPickSecondsDialogHelper(mReminder1Minutes, showDuringDayOption = mIsAllDayTask) {
-            mReminder1Minutes = if (it == -1 || it == 0) it else it / 60
+        showPickSecondsDialogHelper(
+            curMinutes = mReminder1Minutes,
+            showDuringDayOption = mIsAllDayTask,
+            showAbsoluteDateTimeOption = true,
+            eventStartTS = mTask.startTS
+        ) { seconds ->
+            mReminder1Minutes = if (seconds == -1 || seconds == 0) seconds else seconds / 60
             updateReminderTexts()
         }
     }
 
     private fun showReminder2Dialog() {
-        showPickSecondsDialogHelper(mReminder2Minutes, showDuringDayOption = mIsAllDayTask) {
-            mReminder2Minutes = if (it == -1 || it == 0) it else it / 60
+        showPickSecondsDialogHelper(
+            curMinutes = mReminder2Minutes,
+            showDuringDayOption = mIsAllDayTask,
+            showAbsoluteDateTimeOption = true,
+            eventStartTS = mTask.startTS
+        ) { seconds ->
+            mReminder2Minutes = if (seconds == -1 || seconds == 0) seconds else seconds / 60
             updateReminderTexts()
         }
     }
 
     private fun showReminder3Dialog() {
-        showPickSecondsDialogHelper(mReminder3Minutes, showDuringDayOption = mIsAllDayTask) {
-            mReminder3Minutes = if (it == -1 || it == 0) it else it / 60
+        showPickSecondsDialogHelper(
+            curMinutes = mReminder3Minutes,
+            showDuringDayOption = mIsAllDayTask,
+            showAbsoluteDateTimeOption = true,
+            eventStartTS = mTask.startTS
+        ) { seconds ->
+            mReminder3Minutes = if (seconds == -1 || seconds == 0) seconds else seconds / 60
             updateReminderTexts()
         }
     }


### PR DESCRIPTION
ref: https://github.com/FossifyOrg/Calendar/issues/214
Currently this is a minimal (but working) implementation just to check if I'm on the right path (feedback welcome).
Likely needs a good bit of polishing (e.g. check that user doesn't set a reminder _after_ an event etc.).

**Needs my same named Commons branch merged too to build:**
https://github.com/nofishonfriday/Fossify-Commons/tree/feat-pick-date-time-for-reminder


#### Type of change(s)
- [ ] Bug fix
- [x] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- Added an option to choose (absolute) date/time for reminders via a date/time picker 

#### Tests performed
- Basic manual test in simulator

#### Before & after preview
After: (note new option: "Pick date and time")

<img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/3998adcb-03b8-4266-8dfb-e52ec25a88f6" width=273 />

#### Closes the following issue(s)
- Closes #214

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

