### PR TITLE
fix: allow title and location fields to wrap long text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed event text readability on colored backgrounds ([#1065])
 - Fixed invisible current time indicator in weekly view ([#99])
 - Fixed stuck zoom level in weekly view on some devices ([#621])
+- Long title, location fields now wrap in task/event editors ([#1177])
 
 ## [1.10.3] - 2026-02-14
 ### Changed
@@ -253,6 +254,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1024]: https://github.com/FossifyOrg/Calendar/issues/1024
 [#1065]: https://github.com/FossifyOrg/Calendar/issues/1065
 [#1157]: https://github.com/FossifyOrg/Calendar/issues/1157
+[#1177]: https://github.com/FossifyOrg/Calendar/issues/1177
 
 [Unreleased]: https://github.com/FossifyOrg/Calendar/compare/1.10.3...HEAD
 [1.10.3]: https://github.com/FossifyOrg/Calendar/compare/1.10.2...1.10.3

--- a/app/src/main/res/layout/activity_event.xml
+++ b/app/src/main/res/layout/activity_event.xml
@@ -45,7 +45,6 @@
                 android:hint="@string/title"
                 android:inputType="textCapSentences"
                 android:maxLength="180"
-                android:maxLines="1"
                 android:minEms="20"
                 android:textCursorDrawable="@null"
                 android:textSize="@dimen/day_text_size" />
@@ -61,7 +60,6 @@
                 android:hint="@string/location"
                 android:inputType="textCapWords"
                 android:maxLength="180"
-                android:maxLines="1"
                 android:minEms="20"
                 android:textCursorDrawable="@null"
                 android:textSize="@dimen/day_text_size" />

--- a/app/src/main/res/layout/activity_task.xml
+++ b/app/src/main/res/layout/activity_task.xml
@@ -45,7 +45,6 @@
                 android:hint="@string/title"
                 android:inputType="textCapSentences"
                 android:maxLength="180"
-                android:maxLines="1"
                 android:minEms="20"
                 android:textCursorDrawable="@null"
                 android:textSize="@dimen/day_text_size" />


### PR DESCRIPTION
## Summary

Closes #1177

Both the **Title** and **Location** fields in the event editor had `android:maxLines="1"`, which caused long text to scroll horizontally and be clipped rather than wrapping to a new line.

### Root cause

`android:maxLines="1"` on an `EditText` forces the field to display only one line of text with overflow hidden. It does **not** affect input behaviour — users cannot type newlines, but the field should wrap visually when populated with long data from a CalDAV sync.

### Fix

Remove `android:maxLines="1"` from `event_title` and `event_location` in `activity_event.xml`.

- `event_title` (`inputType="textCapSentences"`) — single-line input is preserved by `inputType`; text now wraps visually across lines.
- `event_location` (`inputType="textCapWords"`) — same; autocomplete continues to work normally.

**No Kotlin/Java changes.** This is a 2-line XML deletion.

## Test plan

- [ ] Create or import an event with a long title (100+ chars) — field wraps instead of clipping
- [ ] Create or import an event with a long location — field wraps instead of clipping
- [ ] Short titles/locations still display on one line (no regression)
- [ ] Autocomplete still works on the Location field
- [ ] Enter key on Title still moves focus to next field