### PR TITLE
fix: display leap year birthdays on the day following non-leap year #1087

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed event text readability on colored backgrounds ([#1065])
 - Fixed invisible current time indicator in weekly view ([#99])
 - Fixed stuck zoom level in weekly view on some devices ([#621])
+- Fixed leap day birthdays not showing in non-leap years ([#1087])
 
 ## [1.10.3] - 2026-02-14
 ### Changed

--- a/app/src/main/kotlin/org/fossify/calendar/models/Event.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/models/Event.kt
@@ -82,7 +82,8 @@ data class Event(
                     repeatInterval % YEAR == 0 -> when (repeatRule) {
                         REPEAT_ORDER_WEEKDAY -> addXthDayInterval(oldStart, original, false)
                         REPEAT_ORDER_WEEKDAY_USE_LAST -> addXthDayInterval(oldStart, original, true)
-                        else -> addYearsWithSameDay(oldStart)
+                        else -> addYearsWithSameDay(oldStart, original)
+
                     }
 
                     repeatInterval % MONTH == 0 -> when (repeatRule) {
@@ -110,15 +111,27 @@ data class Event(
     }
 
     // if an event should happen on 29th Feb. with Same Day yearly repetition, show it only on leap years
-    private fun addYearsWithSameDay(currStart: DateTime): DateTime {
+    // show on March 1st in non-leap years
+    private fun addYearsWithSameDay(currStart: DateTime, original: Event): DateTime {
+        val originalDateTime = Formatter.getDateTimeFromTS(original.startTS)
+        val originalDay = originalDateTime.dayOfMonth
+        val originalMonth = originalDateTime.monthOfYear
         var newDateTime = currStart.plusYears(repeatInterval / YEAR)
 
-        // Date may slide within the same month
-        if (newDateTime.dayOfMonth != currStart.dayOfMonth) {
-            while (newDateTime.dayOfMonth().maximumValue < currStart.dayOfMonth) {
+        if (originalMonth == 2 && originalDay == 29) {
+            if (newDateTime.year().isLeap) {
+                //show on 29th Feb. (leap year)
+                newDateTime = newDateTime.withMonthOfYear(2).withDayOfMonth(29)
+            } else {
+                // show on March 1st (non-leap year)
+                newDateTime = newDateTime.withMonthOfYear(3).withDayOfMonth(1)
+            }
+        } else if (newDateTime.dayOfMonth != currStart.dayOfMonth) {
+            // Date may slide within the same month
+            while (newDateTime.dayOfMonth().maximumValue < originalDay) {
                 newDateTime = newDateTime.plusYears(repeatInterval / YEAR)
             }
-            newDateTime = newDateTime.withDayOfMonth(currStart.dayOfMonth)
+            newDateTime = newDateTime.withDayOfMonth(originalDay)
         }
         return newDateTime
     }

--- a/app/src/main/kotlin/org/fossify/calendar/models/Event.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/models/Event.kt
@@ -71,6 +71,8 @@ data class Event(
 
     companion object {
         private const val serialVersionUID = -32456795132345616L
+        private const val LEAP_DAY = 29
+        private const val FIRST_DAY = 1
     }
 
     fun addIntervalTime(original: Event) {
@@ -118,13 +120,13 @@ data class Event(
         val originalMonth = originalDateTime.monthOfYear
         var newDateTime = currStart.plusYears(repeatInterval / YEAR)
 
-        if (originalMonth == 2 && originalDay == 29) {
+        if (originalMonth == DateTimeConstants.FEBRUARY && originalDay == LEAP_DAY) {
             if (newDateTime.year().isLeap) {
                 //show on 29th Feb. (leap year)
-                newDateTime = newDateTime.withMonthOfYear(2).withDayOfMonth(29)
+                newDateTime = newDateTime.withMonthOfYear(DateTimeConstants.FEBRUARY).withDayOfMonth(LEAP_DAY)
             } else {
                 // show on March 1st (non-leap year)
-                newDateTime = newDateTime.withMonthOfYear(3).withDayOfMonth(1)
+                newDateTime = newDateTime.withMonthOfYear(DateTimeConstants.MARCH).withDayOfMonth(FIRST_DAY)
             }
         } else if (newDateTime.dayOfMonth != currStart.dayOfMonth) {
             // Date may slide within the same month


### PR DESCRIPTION


<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Contact birthdays set on Feb 29 (leap day) were not displayed in non-leap years, causing them to appear only once every 4 years.
- Modified `addYearsWithSameDay()` in `Event.kt` to display leap day events on March 1st in non-leap years, and on Feb 29 in leap years.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
- Created a contact with a birthday on Feb 29, 2024
- Imported birthdays into Fossify Calendar.
- Verified the birthday now appears on March 1st in non-leap years (2025, 2026, 2027)
- Verified the birthday still appears on Feb 29 in leap years ( 2028 )
- Tested on emulator Pixel 7

#### Before & after preview
<!-- For changes affecting UI, consider attaching screenshots or a video. Delete this section otherwise. -->
<img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/dc07cef3-ee23-4418-9873-626012be906b" width=188 />

<img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/b82b5ab4-5818-4f24-b223-9565d83555da" width=215 />

<img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/17cd7abc-f935-4b40-92b3-bb3ea72d3dc1" width=187 />

<img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/6f17d262-ac86-4e78-a257-432da582706e" width=202 />

<img alt="ignoreImageMinify" src="https://github.com/user-attachments/assets/2b9e37a2-1777-401f-b5e1-cc842fcf5bc6" width=204 />


#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
<!-- Fossify has an **issue first** policy. Please only work on **accepted** features and bug reports. -->

- Closes #1087

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
