### PR TITLE
Fix/recurrence respect event timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed event text readability on colored backgrounds ([#1065])
 - Fixed invisible current time indicator in weekly view ([#99])
 - Fixed stuck zoom level in weekly view on some devices ([#621])
+- Fixed recurring events drifting by an hour after DST transitions ([#165])
 
 ## [1.10.3] - 2026-02-14
 ### Changed
@@ -217,6 +218,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#135]: https://github.com/FossifyOrg/Calendar/issues/135
 [#138]: https://github.com/FossifyOrg/Calendar/issues/138
 [#148]: https://github.com/FossifyOrg/Calendar/issues/148
+[#165]: https://github.com/FossifyOrg/Calendar/issues/165
 [#196]: https://github.com/FossifyOrg/Calendar/issues/196
 [#217]: https://github.com/FossifyOrg/Calendar/issues/217
 [#262]: https://github.com/FossifyOrg/Calendar/issues/262

--- a/app/src/main/kotlin/org/fossify/calendar/models/Event.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/models/Event.kt
@@ -2,6 +2,7 @@ package org.fossify.calendar.models
 
 import android.provider.CalendarContract
 import android.provider.CalendarContract.Attendees
+import android.util.Log
 import androidx.collection.LongSparseArray
 import androidx.room.ColumnInfo
 import androidx.room.Entity
@@ -74,16 +75,7 @@ data class Event(
     }
 
     fun addIntervalTime(original: Event) {
-        val zone = if (timeZone.isNotEmpty()) {
-            try {
-                DateTimeZone.forID(timeZone)
-            } catch (e: IllegalArgumentException) {
-                DateTimeZone.getDefault()
-            }
-        } else {
-            DateTimeZone.getDefault()
-        }
-        val oldStart = Formatter.getDateTimeFromTS(startTS, zone)
+        val oldStart = Formatter.getDateTimeFromTS(startTS, resolveTimeZone())
         val newStart = when (repeatInterval) {
             DAY -> oldStart.plusDays(1)
             else -> {
@@ -116,6 +108,20 @@ data class Event(
         val newEndTS = newStartTS + (endTS - startTS)
         startTS = newStartTS
         endTS = newEndTS
+    }
+
+    // Returns the event's time zone, or the device default if unset or unrecognized.
+    private fun resolveTimeZone(): DateTimeZone {
+        return if (timeZone.isNotEmpty()) {
+            try {
+                DateTimeZone.forID(timeZone)
+            } catch (e: IllegalArgumentException) {
+                Log.w("Event", "Unrecognized timezone '$timeZone', using default", e)
+                DateTimeZone.getDefault()
+            }
+        } else {
+            DateTimeZone.getDefault()
+        }
     }
 
     // if an event should happen on 29th Feb. with Same Day yearly repetition, show it only on leap years

--- a/app/src/main/kotlin/org/fossify/calendar/models/Event.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/models/Event.kt
@@ -74,7 +74,16 @@ data class Event(
     }
 
     fun addIntervalTime(original: Event) {
-        val oldStart = Formatter.getDateTimeFromTS(startTS)
+        val zone = if (timeZone.isNotEmpty()) {
+            try {
+                DateTimeZone.forID(timeZone)
+            } catch (e: IllegalArgumentException) {
+                DateTimeZone.getDefault()
+            }
+        } else {
+            DateTimeZone.getDefault()
+        }
+        val oldStart = Formatter.getDateTimeFromTS(startTS, zone)
         val newStart = when (repeatInterval) {
             DAY -> oldStart.plusDays(1)
             else -> {


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
`Event.addIntervalTime` now uses the event's stored `timeZone` for recurrence math, falling back to the device default if it's empty or not recognized.

`addIntervalTime` wasn't using the event's `timeZone` field at all, it was just defaulting to whatever zone the device was in. Once a recurring event crossed a DST boundary, every following occurrence drifted by an hour, i.e. an event created in ET but read in AST would display the right time before the DST transition and the wrong time after.

#### Tests performed
Built debug APK, installed on a phone in `America/Puerto_Rico` which doesn't observe DST. Verified against a real Outlook calendar synced to the device via the Outlook Android app.

| # | Source TZ | Recurrence | DST regime | Result |
|---|-----------|------------|------------|--------|
| 1 | Pacific Time | Weekly | US spring-forward (Mar 8 2026) | Pass |
| 2 | W. Europe Time | Weekly | EU spring-forward (Mar 29 2026) | Pass |
| 3 | Tokyo Standard Time | Weekly | None (Tokyo no DST) | Pass * |
| 4 | AUS Eastern Time | Weekly | AU fall-back (Apr 5 2026) | Pass * |
| 5 | Eastern Time | Monthly on the 15th | US spring-forward | Pass |
| 6 | Eastern Time | Yearly on Mar 20 | (none, always EDT) | Pass |

For each test, occurrences before and after the DST boundary were verified against expected local times in AST. Detailed observed vs expected values posted in a follow-up comment.

\* Notes for tests 3 and 4:
While testing, I noticed that for events with non-local source timezones, the calendar view places each occurrence on the source-timezone date rather than the device-local date. This affected the displayed dates in tests 3 and 4 (times were correct, dates were off). Confirmed the same date behavior in release 1.10.3, seems to be unrelated to this PR.

May also address #506, #535, and possibly #71/#262, but I haven't verified against those reporters reproduction steps.

#### Closes the following issue(s)
- Closes #165

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.
