### PR TITLE
fix: import weekday-only recurring events (FREQ=DAILY;BYDAY)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed event text readability on colored backgrounds ([#1065])
 - Fixed invisible current time indicator in weekly view ([#99])
 - Fixed stuck zoom level in weekly view on some devices ([#621])
+- Fixed importing recurring events that repeat only on weekdays (RRULE FREQ=DAILY with BYDAY, e.g. from Thunderbird), which were previously shown on every day including weekends ([#232])
 
 ## [1.10.3] - 2026-02-14
 ### Changed
@@ -219,6 +220,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#148]: https://github.com/FossifyOrg/Calendar/issues/148
 [#196]: https://github.com/FossifyOrg/Calendar/issues/196
 [#217]: https://github.com/FossifyOrg/Calendar/issues/217
+[#232]: https://github.com/FossifyOrg/Calendar/issues/232
 [#262]: https://github.com/FossifyOrg/Calendar/issues/262
 [#337]: https://github.com/FossifyOrg/Calendar/issues/337
 [#393]: https://github.com/FossifyOrg/Calendar/issues/393

--- a/app/src/main/kotlin/org/fossify/calendar/helpers/Parser.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/helpers/Parser.kt
@@ -35,10 +35,10 @@ class Parser {
                     repeatRule = 1 shl (start.dayOfWeek - 1)
                 } else if (value == MONTHLY || value == YEARLY) {
                     repeatRule = REPEAT_SAME_DAY
-                } else if (value == DAILY && fullString.contains(INTERVAL)) {
+                } else if (value == DAILY && (fullString.contains(INTERVAL) || fullString.contains("BYDAY"))) {
                     val interval = fullString.substringAfter("$INTERVAL=").substringBefore(";")
                     // properly handle events repeating by 14 days or so, just add a repeat rule to specify a day of the week
-                    if (interval.areDigitsOnly() && interval.toInt() % 7 == 0) {
+                    if (fullString.contains(INTERVAL) && interval.areDigitsOnly() && interval.toInt() % 7 == 0) {
                         val dateTime = Formatter.getDateTimeFromTS(startTS)
                         repeatRule = 1 shl (dateTime.dayOfWeek - 1)
                     } else if (fullString.contains("BYDAY")) {


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix

#### What changed and why
Recurring events exported as `RRULE:FREQ=DAILY;BYDAY=MO,TU,WE,TH,FR` **without** an `INTERVAL` field (the format Thunderbird / DAVx5 use for "repeat every weekday") were imported as plain every-day events and therefore also appeared on Saturdays and Sundays (issue #232).

In `Parser.parseRepeatInterval()`, the `FREQ=DAILY` branch that converts a weekday-restricted daily rule into a weekly repetition was gated on the RRULE containing `INTERVAL`:

```kotlin
} else if (value == DAILY && fullString.contains(INTERVAL)) {
```

When only `BYDAY` (and no `INTERVAL`) is present, this branch is skipped, so `repeatInterval` stays `DAY` (86400). The later `BYDAY` handler is then a no-op because `repeatInterval.isXWeeklyRepetition()` is false for a daily interval, so no weekday bitmask is ever applied and the event repeats every day.

The fix enters the branch when either `INTERVAL` or `BYDAY` is present, and additionally guards the "interval is a multiple of 7" check with an `INTERVAL` presence test (so `BYDAY`-only rules fall through to the `BYDAY` conversion and never call `interval.toInt()` on a non-numeric value):

```kotlin
} else if (value == DAILY && (fullString.contains(INTERVAL) || fullString.contains("BYDAY"))) {
    val interval = fullString.substringAfter("$INTERVAL=").substringBefore(";")
    if (fullString.contains(INTERVAL) && interval.areDigitsOnly() && interval.toInt() % 7 == 0) {
        ...
    } else if (fullString.contains("BYDAY")) {
        repeatInterval = WEEK_SECONDS
    }
}
```

This sets `repeatInterval = WEEK_SECONDS` (604800), so the existing `BYDAY` handler produces the correct Mon-Fri bitmask, making `FREQ=DAILY;BYDAY=...` behave identically to `FREQ=WEEKLY;BYDAY=...`. All previously handled cases (plain `FREQ=DAILY`, `FREQ=DAILY;INTERVAL=n`, `FREQ=DAILY;INTERVAL=14`, `FREQ=DAILY;INTERVAL=1;BYDAY=...`) keep their prior behavior.

#### Tests performed
Built the `fossDebug` variant and verified on an Android 15 (API 35) emulator:

Imported ICS with RRULE:FREQ=DAILY;BYDAY=MO,TU,WE,TH,FR (DTSTART Mon 2026-07-06). Month view shows 'Weekday standup' on every weekday (Mon-Fri) and absent on all weekends. Event detail shows repetition = Weekly, Repeat on Mon,Tue,Wed,Thu,Fri (not plain Daily).

Also confirmed `detekt`, `lint`, unit tests and the build all pass locally (CI-equivalent).

#### Closes the following issue(s)
- Closes #232

#### Checklist
- [x] I read the contribution guidelines.
- [x] I manually tested my changes on device/emulator.
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

---
<sub>Coded with Opus 4.8 ultracode.</sub>
