### PR TITLE
fix: show events starting at Unix timestamp 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed event text readability on colored backgrounds ([#1065])
 - Fixed invisible current time indicator in weekly view ([#99])
 - Fixed stuck zoom level in weekly view on some devices ([#621])
+- Fixed events starting at 1970-01-01 00:00 (Unix timestamp 0) not being visible ([#440])
 
 ## [1.10.3] - 2026-02-14
 ### Changed
@@ -224,6 +225,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#393]: https://github.com/FossifyOrg/Calendar/issues/393
 [#394]: https://github.com/FossifyOrg/Calendar/issues/394
 [#406]: https://github.com/FossifyOrg/Calendar/issues/406
+[#440]: https://github.com/FossifyOrg/Calendar/issues/440
 [#484]: https://github.com/FossifyOrg/Calendar/issues/484
 [#486]: https://github.com/FossifyOrg/Calendar/issues/486
 [#550]: https://github.com/FossifyOrg/Calendar/issues/550

--- a/app/detekt-baseline.xml
+++ b/app/detekt-baseline.xml
@@ -275,12 +275,9 @@
     <ID>MaxLineLength:EventListAdapter.kt$EventListAdapter$val eventsToDelete = listItems.filter { selectedKeys.contains((it as? ListEvent)?.hashCode()) } as List&lt;ListEvent&gt;</ID>
     <ID>MaxLineLength:EventListWidgetAdapter.kt$EventListWidgetAdapter$if</ID>
     <ID>MaxLineLength:EventListWidgetAdapter.kt$EventListWidgetAdapter$}</ID>
-    <ID>MaxLineLength:EventsDao.kt$EventsDao$//val selection = "$COL_REMINDER_MINUTES != -1 AND ($COL_START_TS &gt; ? OR $COL_REPEAT_INTERVAL != 0) AND $COL_START_TS != 0"</ID>
-    <ID>MaxLineLength:EventsDao.kt$EventsDao$@Query("SELECT * FROM events WHERE reminder_1_minutes != -1 AND (start_ts &gt; :currentTS OR repeat_interval != 0) AND start_ts != 0")</ID>
-    <ID>MaxLineLength:EventsDao.kt$EventsDao$@Query("SELECT * FROM events WHERE start_ts &lt;= :toTS AND end_ts &gt;= :fromTS AND start_ts != 0 AND repeat_interval = 0 AND event_type IN (:calendarIds) AND (title LIKE :searchQuery OR location LIKE :searchQuery OR description LIKE :searchQuery)")</ID>
-    <ID>MaxLineLength:EventsDao.kt$EventsDao$@Query("SELECT * FROM events WHERE start_ts &lt;= :toTS AND end_ts &gt;= :fromTS AND start_ts != 0 AND repeat_interval = 0 AND event_type IN (:calendarIds)")</ID>
-    <ID>MaxLineLength:EventsDao.kt$EventsDao$@Query("SELECT * FROM events WHERE start_ts &lt;= :toTS AND start_ts != 0 AND repeat_interval != 0 AND event_type IN (:calendarIds) AND (title LIKE :searchQuery OR location LIKE :searchQuery OR description LIKE :searchQuery)")</ID>
-    <ID>MaxLineLength:EventsDao.kt$EventsDao$@Query("SELECT * FROM events WHERE start_ts &lt;= :toTS AND start_ts != 0 AND repeat_interval != 0 AND event_type IN (:calendarIds)")</ID>
+    <ID>MaxLineLength:EventsDao.kt$EventsDao$@Query("SELECT * FROM events WHERE start_ts &lt;= :toTS AND end_ts &gt;= :fromTS AND repeat_interval = 0 AND event_type IN (:calendarIds) AND (title LIKE :searchQuery OR location LIKE :searchQuery OR description LIKE :searchQuery)")</ID>
+    <ID>MaxLineLength:EventsDao.kt$EventsDao$@Query("SELECT * FROM events WHERE start_ts &lt;= :toTS AND end_ts &gt;= :fromTS AND repeat_interval = 0 AND event_type IN (:calendarIds)")</ID>
+    <ID>MaxLineLength:EventsDao.kt$EventsDao$@Query("SELECT * FROM events WHERE start_ts &lt;= :toTS AND repeat_interval != 0 AND event_type IN (:calendarIds) AND (title LIKE :searchQuery OR location LIKE :searchQuery OR description LIKE :searchQuery)")</ID>
     <ID>MaxLineLength:EventsDao.kt$EventsDao$@Query("SELECT * FROM events WHERE start_ts &lt;= :toTS AND start_ts &gt;= :fromTS AND event_type IN (:calendarIds) AND type = $TYPE_TASK")</ID>
     <ID>MaxLineLength:EventsDatabase.kt$EventsDatabase.Companion.&lt;no name provided&gt;$execSQL("CREATE TABLE IF NOT EXISTS `tasks` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `task_id` INTEGER NOT NULL, `start_ts` INTEGER NOT NULL, `flags` INTEGER NOT NULL)")</ID>
     <ID>MaxLineLength:EventsDatabase.kt$EventsDatabase.Companion.&lt;no name provided&gt;$execSQL("CREATE TABLE IF NOT EXISTS `widgets` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `widget_id` INTEGER NOT NULL, `period` INTEGER NOT NULL)")</ID>

--- a/app/src/androidTest/kotlin/org/fossify/calendar/interfaces/EventsDaoGetOneTimeEventsFromToWithCalendarIdsTest.kt
+++ b/app/src/androidTest/kotlin/org/fossify/calendar/interfaces/EventsDaoGetOneTimeEventsFromToWithCalendarIdsTest.kt
@@ -74,12 +74,10 @@ class EventsDaoGetOneTimeEventsFromToWithCalendarIdsTest {
     @Test
     @Throws(Exception::class)
     fun bug440_EventAtMidnightOnFirstJan1970() {
-        expectedFailure("https://github.com/FossifyOrg/Calendar/issues/440") {
-            eventsDao.insertOrUpdate(Event(id = 0, startTS = 0, endTS = 3600, calendarId = calendarId))
+        eventsDao.insertOrUpdate(Event(id = 0, startTS = 0, endTS = 3600, calendarId = calendarId))
 
-            val eventsOnFirstJan1970 = eventsDao.getOneTimeEventsFromToWithCalendarIds(86400, 0, listOf(calendarId))
+        val eventsOnFirstJan1970 = eventsDao.getOneTimeEventsFromToWithCalendarIds(86400, 0, listOf(calendarId))
 
-            Assert.assertEquals(1, eventsOnFirstJan1970.count())
-        }
+        Assert.assertEquals(1, eventsOnFirstJan1970.count())
     }
 }

--- a/app/src/main/kotlin/org/fossify/calendar/interfaces/EventsDao.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/interfaces/EventsDao.kt
@@ -55,14 +55,14 @@ interface EventsDao {
     @Query("SELECT * FROM events WHERE id = :id AND start_ts <= :toTS AND end_ts >= :fromTS AND repeat_interval = 0")
     fun getOneTimeEventFromToWithId(id: Long, toTS: Long, fromTS: Long): List<Event>
 
-    @Query("SELECT * FROM events WHERE start_ts <= :toTS AND end_ts >= :fromTS AND start_ts != 0 AND repeat_interval = 0 AND event_type IN (:calendarIds)")
+    @Query("SELECT * FROM events WHERE start_ts <= :toTS AND end_ts >= :fromTS AND repeat_interval = 0 AND event_type IN (:calendarIds)")
     fun getOneTimeEventsFromToWithCalendarIds(
         toTS: Long,
         fromTS: Long,
         calendarIds: List<Long>
     ): List<Event>
 
-    @Query("SELECT * FROM events WHERE start_ts <= :toTS AND end_ts >= :fromTS AND start_ts != 0 AND repeat_interval = 0 AND event_type IN (:calendarIds) AND (title LIKE :searchQuery OR location LIKE :searchQuery OR description LIKE :searchQuery)")
+    @Query("SELECT * FROM events WHERE start_ts <= :toTS AND end_ts >= :fromTS AND repeat_interval = 0 AND event_type IN (:calendarIds) AND (title LIKE :searchQuery OR location LIKE :searchQuery OR description LIKE :searchQuery)")
     fun getOneTimeEventsFromToWithTypesForSearch(
         toTS: Long,
         fromTS: Long,
@@ -76,10 +76,10 @@ interface EventsDao {
     @Query("SELECT * FROM events WHERE id = :id AND start_ts <= :toTS AND repeat_interval != 0")
     fun getRepeatableEventsOrTasksWithId(id: Long, toTS: Long): List<Event>
 
-    @Query("SELECT * FROM events WHERE start_ts <= :toTS AND start_ts != 0 AND repeat_interval != 0 AND event_type IN (:calendarIds)")
+    @Query("SELECT * FROM events WHERE start_ts <= :toTS AND repeat_interval != 0 AND event_type IN (:calendarIds)")
     fun getRepeatableEventsOrTasksWithCalendarIds(toTS: Long, calendarIds: List<Long>): List<Event>
 
-    @Query("SELECT * FROM events WHERE start_ts <= :toTS AND start_ts != 0 AND repeat_interval != 0 AND event_type IN (:calendarIds) AND (title LIKE :searchQuery OR location LIKE :searchQuery OR description LIKE :searchQuery)")
+    @Query("SELECT * FROM events WHERE start_ts <= :toTS AND repeat_interval != 0 AND event_type IN (:calendarIds) AND (title LIKE :searchQuery OR location LIKE :searchQuery OR description LIKE :searchQuery)")
     fun getRepeatableEventsOrTasksWithTypesForSearch(
         toTS: Long,
         calendarIds: List<Long>,
@@ -104,8 +104,7 @@ interface EventsDao {
     @Query("SELECT * FROM events WHERE id IN (:ids)")
     fun getEventsOrTasksWithIds(ids: List<Long>): List<Event>
 
-    //val selection = "$COL_REMINDER_MINUTES != -1 AND ($COL_START_TS > ? OR $COL_REPEAT_INTERVAL != 0) AND $COL_START_TS != 0"
-    @Query("SELECT * FROM events WHERE reminder_1_minutes != -1 AND (start_ts > :currentTS OR repeat_interval != 0) AND start_ts != 0")
+    @Query("SELECT * FROM events WHERE reminder_1_minutes != -1 AND (start_ts > :currentTS OR repeat_interval != 0)")
     fun getEventsOrTasksAtReboot(currentTS: Long): List<Event>
 
     @Query("SELECT id FROM events")


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix

#### What changed and why
Several `EventsDao` queries carried a stale `AND start_ts != 0` clause inherited from the Simple Calendar era. `start_ts` is a Unix timestamp in seconds, so `start_ts == 0` is exactly 1970-01-01 00:00:00 UTC. Any event landing on that instant — including all-day or yearly-recurring events whose start falls on epoch 0 (e.g. New Year's Day 1970 in GMT+0) — was stored in the database but silently filtered out of day/list views, search, and reboot reminder rescheduling, so it never became visible.

The clause was also inconsistent: the sibling queries without `calendarIds` (`getOneTimeEventsOrTasksFromTo`, `getRepeatableEventsOrTasksWithCalendarIds(toTS)`) never had it, confirming it is a legacy heuristic rather than intentional behaviour. No code inserts `start_ts = 0` as a hidden sentinel (only the `Event` model default `0L` and the UI-only `ListEvent.empty`).

This PR removes the clause from the five affected queries:
- `getOneTimeEventsFromToWithCalendarIds`
- `getOneTimeEventsFromToWithTypesForSearch`
- `getRepeatableEventsOrTasksWithCalendarIds(toTS, calendarIds)`
- `getRepeatableEventsOrTasksWithTypesForSearch`
- `getEventsOrTasksAtReboot`

Removing it from the reboot query is safe: a non-repeating event at ts 0 is already excluded by `(start_ts > :currentTS OR repeat_interval != 0)`, while a repeating one legitimately has future occurrences that need reminders. The now-obsolete legacy comment above that query is dropped.

The existing instrumented test `bug440_EventAtMidnightOnFirstJan1970` (previously wrapped in `expectedFailure`) is unwrapped so it now passes, and the detekt baseline is updated to match the shortened query lines.

#### Tests performed
Built the `fossDebug` variant and verified on an Android 15 (API 35) emulator:

Set device timezone to UTC (Etc/GMT); created event at Jan 1 1970 12:00 AM (start_ts=0). Reminder notification fired showing 'January 1 1970, 12:00 AM'. Searching 'Epoch' returned the event under JANUARY 1970 / 1 Thursday / Epoch 12:00 AM. Previously start_ts!=0 filter would hide it.

Also confirmed `detekt`, `lint`, unit tests and the build all pass locally (CI-equivalent).

#### Closes the following issue(s)
- Closes #440

#### Checklist
- [x] I read the contribution guidelines.
- [x] I manually tested my changes on device/emulator.
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

---
<sub>Coded with Opus 4.8 ultracode.</sub>
