### PR TITLE
fix: show time until the event (not the reminder) in the save countdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated holiday data
 
 ### Fixed
+- Fixed the save-event countdown to show time until the event instead of time until the reminder ([#1073])
 - Fixed event text readability on colored backgrounds ([#1065])
 - Fixed invisible current time indicator in weekly view ([#99])
 - Fixed stuck zoom level in weekly view on some devices ([#621])
@@ -252,6 +253,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#1019]: https://github.com/FossifyOrg/Calendar/issues/1019
 [#1024]: https://github.com/FossifyOrg/Calendar/issues/1024
 [#1065]: https://github.com/FossifyOrg/Calendar/issues/1065
+[#1073]: https://github.com/FossifyOrg/Calendar/issues/1073
 [#1157]: https://github.com/FossifyOrg/Calendar/issues/1157
 
 [Unreleased]: https://github.com/FossifyOrg/Calendar/compare/1.10.3...HEAD

--- a/app/src/main/kotlin/org/fossify/calendar/extensions/Context.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/extensions/Context.kt
@@ -243,10 +243,10 @@ fun Context.scheduleEventIn(notifyAtMillis: Long, event: Event, showToasts: Bool
 
     val newNotifyAtMillis = notifyAtMillis + 1000
     if (showToasts) {
-        val secondsTillNotification = (newNotifyAtMillis - now) / 1000
+        val secondsTillEvent = event.getEventStartTS() - getNowSeconds()
         val msg = String.format(
             getString(org.fossify.commons.R.string.time_remaining),
-            formatSecondsToTimeString(secondsTillNotification.toInt())
+            formatSecondsToTimeString(secondsTillEvent.toInt())
         )
         toast(msg)
     }


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix

#### What changed and why
When saving an event that has at least one notification reminder, `Context.scheduleNextEventReminder()` picks the next reminder time `(curEvent.getEventStartTS() - curReminder) * 1000L` and passes it to `Context.scheduleEventIn()` as `notifyAtMillis`. Inside `scheduleEventIn`, the "time remaining" toast was computed from the notification/alarm time rather than the event start:

```kotlin
val secondsTillNotification = (newNotifyAtMillis - now) / 1000
```

So the toast counted down to the reminder, not the event. Example: an event 2 hours away with a "10 minutes before" reminder showed "1 hour, 50 minutes" instead of "2 hours".

This changes only the toast computation to use the event start time:

```kotlin
val secondsTillEvent = event.getEventStartTS() - getNowSeconds()
```

Both `getNowSeconds()` and `event.getEventStartTS()` are already imported/used in this file, so no new imports are needed. Scheduling behaviour and the `notifyAtMillis < now` guard are deliberately left untouched, so the snooze / reschedule path (`rescheduleReminder`) is unaffected. On this code path `secondsTillEvent` is guaranteed positive because `scheduleNextEventReminder` only calls `scheduleEventIn` when `curEvent.getEventStartTS() - curReminder > now` with a non-negative reminder offset, so start > now.

#### Tests performed
- `detekt`, `lint`, unit tests and the build all pass locally (CI-equivalent).
- Verified on an Android 15 (API 35) emulator that creating an event with a notification reminder saves correctly and the reminder fires.
- Source-verified: the save-time countdown toast is now computed from the event start (`getEventStartTS() - getNowSeconds()`) instead of the next reminder time.
- Note: the toast itself is transient (~2s, rendered during the activity-close transition) and could not be frozen into a readable screenshot despite several capture methods, so the exact toast text is verified via CI + code review.

#### Closes the following issue(s)
- Closes #1073

#### Checklist
- [x] I read the contribution guidelines.
- [ ] I manually tested my changes on device/emulator (verified via CI + source review; see Tests performed).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

---
<sub>Coded with Opus 4.8 ultracode.</sub>
