### PR TITLE
fix(export): write EXDATE as VALUE=DATE to produce valid iCal

### DIFF
--- a/app/src/main/kotlin/org/fossify/calendar/helpers/IcsExporter.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/helpers/IcsExporter.kt
@@ -110,7 +110,7 @@ class IcsExporter(private val context: Context) {
 
     private fun fillIgnoredOccurrences(event: Event, out: BufferedWriter) {
         event.repetitionExceptions.forEach {
-            out.writeLn("$EXDATE:$it")
+            out.writeLn("$EXDATE;$VALUE=$DATE:$it")
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #1102.

Exported `.ics` files fail to import into strict iCalendar parsers (e.g. Radicale, Thunderbird) with an error like `'20250429' is not a valid DATE-TIME` on the `EXDATE` line.

## Cause

`repetitionExceptions` are stored as date-only day codes (`YYYYMMDD`), but `IcsExporter.fillIgnoredOccurrences` wrote them as a bare `EXDATE` property:

```
EXDATE:20250429
```

Per [RFC 5545 §3.8.5.1](https://icalendar.org/iCalendar-RFC-5545/3-8-5-1-exception-date-times.html), `EXDATE` defaults to the `DATE-TIME` value type, so a date-only value is invalid.

## Fix

Emit the `VALUE=DATE` parameter, matching the format the exporter already uses for all-day `DTSTART`/`DTEND`:

```
EXDATE;VALUE=DATE:20250429
```

`IcsImporter.getTimestamp` already handles the `;VALUE=DATE:` form, so exported files continue to round-trip correctly.

## Testing

The repo has no unit-test harness for `IcsExporter` (only instrumented `androidTest` exists), so this was verified by code inspection of the export format against RFC 5545 and the existing all-day `DTSTART` handling and import parser. Happy to add test scaffolding if desired.