### PR TITLE
fix(l10n): correct Catalan string in Spanish translation

### DIFF
--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -186,7 +186,7 @@
     <string name="other_time">Otro momento</string>
     <string name="highlight_weekends">Resaltar los fines de semana en algunas vistas</string>
     <string name="highlight_weekends_color">Color de los fines de semana resaltados</string>
-    <string name="allow_changing_time_zones">Permetre canviar els fusos horaris dels esdeveniments</string>
+    <string name="allow_changing_time_zones">Permitir cambiar las zonas horarias de los eventos</string>
     <string name="manage_quick_filter_event_types">Administrar calendarios de filtro rápido</string>
     <string name="allow_creating_tasks">Permitir crear tareas</string>
     <string name="select_caldav_calendars">Seleccionar los calendarios que se van a sincronizar</string>


### PR DESCRIPTION
## Summary

Closes #1258.

The Spanish (`values-es`) value for `allow_changing_time_zones` was mistakenly copied from the Catalan (`values-ca`) translation:

- Before (Catalan): `Permetre canviar els fusos horaris dels esdeveniments`
- After (Spanish): `Permitir cambiar las zonas horarias de los eventos`

English source: `Allow changing event time zones`

This string appears in Settings → Events when the system language is Spanish.

> Note: if translations are managed via an external platform, feel free to close this and apply it there instead.