### PR TITLE
fix: rebuild the quick filter bar after a CalDAV refresh

### DIFF
--- a/app/src/main/kotlin/org/fossify/calendar/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/calendar/activities/MainActivity.kt
@@ -656,6 +656,7 @@ class MainActivity : SimpleActivity(), RefreshRecyclerViewListener {
         ensureBackgroundThread {
             calDAVHelper.refreshCalendars(showToasts = false, scheduleNextSync = true) {
                 refreshViewPager()
+                setupQuickFilter()
             }
         }
     }
@@ -675,6 +676,11 @@ class MainActivity : SimpleActivity(), RefreshRecyclerViewListener {
 
     private fun calDAVChanged() {
         refreshViewPager()
+        // The quick filter bar keeps its own snapshot of the calendars, so a
+        // colour or name that changed on the server was shown in the views
+        // but not in the bar until the bar was rebuilt. Same in
+        // updateCalDAVEvents(), the refresh that runs on its own.
+        setupQuickFilter()
         if (showCalDAVRefreshToast) {
             toast(R.string.refreshing_complete)
         }


### PR DESCRIPTION
Fixes #1292: after a CalDAV refresh, a calendar's new colour or name shows
in the views but the quick filter bar keeps the old one; only clearing the
app's data made it show the new one.

Both refresh paths, updateCalDAVEvents() and calDAVChanged(), only called
refreshViewPager(); the bar is rebuilt by setupQuickFilter(), as every
other flow that changes calendars already does. Call it in both places.

Tested with a foss debug build of this branch (main at d985d5e) on a
Pixel 9a, Android 17, with DAVx5 and Nextcloud: the chip follows the views
on the app's own refresh.

